### PR TITLE
Change video link to download link

### DIFF
--- a/notebooks/201-vision-monodepth/201-vision-monodepth.ipynb
+++ b/notebooks/201-vision-monodepth/201-vision-monodepth.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ruled-squad",
+   "id": "artistic-birmingham",
    "metadata": {
     "id": "moved-collapse"
    },
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "modular-pound",
+   "id": "split-laundry",
    "metadata": {},
    "source": [
     "<img src=\"monodepth.gif\">"
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "black-solid",
+   "id": "proved-cloud",
    "metadata": {},
    "source": [
     "### What is Monodepth?\n",
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "conditional-excitement",
+   "id": "wound-regard",
    "metadata": {
     "id": "creative-cisco"
    },
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "reliable-argument",
+   "id": "running-logging",
    "metadata": {
     "id": "faced-honolulu"
    },
@@ -54,7 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aware-wales",
+   "id": "adapted-supply",
    "metadata": {
     "id": "ahead-spider"
    },
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "alien-genius",
+   "id": "combined-substitute",
    "metadata": {
     "id": "contained-office"
    },
@@ -86,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "pharmaceutical-christian",
+   "id": "selected-horizon",
    "metadata": {
     "id": "amber-lithuania"
    },
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "weighted-patrol",
+   "id": "peripheral-recognition",
    "metadata": {},
    "source": [
     "## Functions"
@@ -110,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "prospective-involvement",
+   "id": "union-composite",
    "metadata": {
     "id": "endangered-constraint"
    },
@@ -124,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "checked-annual",
+   "id": "western-bulgarian",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "crazy-mercury",
+   "id": "subtle-extreme",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "nutritional-perspective",
+   "id": "yellow-cornwall",
    "metadata": {
     "id": "sensitive-wagner"
    },
@@ -182,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ranging-genesis",
+   "id": "optimum-premiere",
    "metadata": {
     "id": "complete-brother"
    },
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "instant-microphone",
+   "id": "removable-softball",
    "metadata": {
     "id": "compact-bargain"
    },
@@ -216,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "stock-thursday",
+   "id": "intensive-client",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "appreciated-russia",
+   "id": "dominican-james",
    "metadata": {
     "id": "taken-spanking"
    },
@@ -250,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "federal-cooling",
+   "id": "challenging-sterling",
    "metadata": {
     "id": "banner-kruger"
    },
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "english-legislation",
+   "id": "furnished-forty",
    "metadata": {},
    "source": [
     "### Display monodepth image"
@@ -274,7 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "timely-toronto",
+   "id": "eleven-beatles",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -292,7 +292,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "awful-drilling",
+   "id": "later-kennedy",
    "metadata": {
     "id": "descending-cache"
    },
@@ -304,7 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "literary-leave",
+   "id": "contained-switzerland",
    "metadata": {},
    "source": [
     "### Download and load video"
@@ -313,7 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bored-sperm",
+   "id": "criminal-vertical",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -334,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aggregate-holiday",
+   "id": "right-gibson",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +355,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "unlikely-master",
+   "id": "minute-manner",
    "metadata": {},
    "source": [
     "### Do Inference on video and create monodepth video"
@@ -364,7 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "weird-words",
+   "id": "amino-constitutional",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -447,7 +447,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "biological-coffee",
+   "id": "hungarian-station",
    "metadata": {
     "id": "bZ89ZI369KjA"
    },
@@ -458,7 +458,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "classical-religious",
+   "id": "sweet-oriental",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -470,7 +470,8 @@
     "    print(f\"Showing monodepth video {result_video_path.resolve()}\")\n",
     "    display(video)\n",
     "    video_link = FileLink(result_video_path)\n",
-    "    display(HTML(f'If you cannot see the video in your browser, please right click on the following link to download the video {video_link._repr_html_()}'))\n"
+    "    video_link.html_link_str = \"<a href='%s' download>%s</a>\"\n",
+    "    display(HTML(f'If you cannot see the video in your browser, please click on the following link to download the video {video_link._repr_html_()}'))\n"
    ]
   }
  ],
@@ -496,7 +497,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
With this change, clicking on the link near the monodepth result video will download the video, instead of Jupyter trying to display it, resulting in an error. I tested only on Windows, but adding "download" to the link is a standard. See https://caniuse.com/?search=download%20attribute