### PR TITLE
Add Python 3.8 to nbval.yml and limit nbval runs

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -1,6 +1,12 @@
 name: nbval
 
-on: [push, pull_request]
+on: 
+  push:
+    paths-ignore:
+    - '**.md'
+  pull_request:
+    paths-ignore:
+    - '**.md'
 
 jobs:
   build:
@@ -8,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
-        python: [3.6, 3.7]
+        python: [3.6, 3.7, 3.8]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Do not run notebook validation when only markdown files are changed.