### PR TITLE
Add quotes around paths in MO command and remove deprecated option from MO

### DIFF
--- a/notebooks/101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb
+++ b/notebooks/101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb
@@ -69,7 +69,7 @@
     "\n",
     "### Convert TensorFlow model to OpenVINO IR Format\n",
     "\n",
-    "Call the OpenVINO Model Optimizer tool to convert the TensorFlow model to OpenVINO IR, with FP16 precision. The models are saved to the current directory. We add the mean values to the model with `--move_to_preprocess` and scale the output with the standard deviation with `--scale_values`. With these options, it is not necessary to normalize input data before propagating it through the network. The original model expects input images in RGB format. The converted model also expects images in RGB format. If you want the converted model to work with BGR images, you can use the `--reverse-input-channels` option. See the [Model Optimizer Developer Guide](https://docs.openvinotoolkit.org/latest/openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html) for more information about Model Optimizer, including a description of the command line options. Check the [model documentation](https://github.com/openvinotoolkit/open_model_zoo/blob/master/models/public/mobilenet-v3-small-1.0-224-tf/mobilenet-v3-small-1.0-224-tf.md) for information about the model, including input shape, expected color order and mean values. \n",
+    "Call the OpenVINO Model Optimizer tool to convert the TensorFlow model to OpenVINO IR, with FP16 precision. The models are saved to the current directory. We add the mean values to the model and scale the output with the standard deviation with `--scale_values`. With these options, it is not necessary to normalize input data before propagating it through the network. The original model expects input images in RGB format. The converted model also expects images in RGB format. If you want the converted model to work with BGR images, you can use the `--reverse-input-channels` option. See the [Model Optimizer Developer Guide](https://docs.openvinotoolkit.org/latest/openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html) for more information about Model Optimizer, including a description of the command line options. Check the [model documentation](https://github.com/openvinotoolkit/open_model_zoo/blob/master/models/public/mobilenet-v3-small-1.0-224-tf/mobilenet-v3-small-1.0-224-tf.md) for information about the model, including input shape, expected color order and mean values. \n",
     "\n",
     "We first construct the command for Model Optimizer, and then execute this command in the notebook by prepending the command with a `!`. There may be some errors or warnings in the output. Model Optimization was succesful if the last lines of the output include `[ SUCCESS ] Generated IR version 10 model.\n",
     "`"
@@ -78,22 +78,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Get the path to the Model Optimizer script\n",
     "mo_path = str(Path(mo_tf.__file__))\n",
     "\n",
     "# Construct the command for Model Optimizer\n",
-    "mo_command = f\"\"\"{sys.executable} \n",
+    "mo_command = f\"\"\"\"{sys.executable}\"\n",
     "                 \"{mo_path}\" \n",
     "                 --input_model \"{model_path}\" \n",
     "                 --input_shape \"[1,224,224,3]\" \n",
     "                 --mean_values=\"[127.5,127.5,127.5]\"\n",
     "                 --scale_values=\"[127.5]\" \n",
-    "                 --move_to_preprocess\n",
     "                 --data_type FP16 \n",
-    "                 --output_dir {model_path.parent}\"\"\"\n",
+    "                 --output_dir \"{model_path.parent}\"\n",
+    "                 \"\"\"\n",
     "mo_command = \" \".join(mo_command.split())\n",
     "print(\"Model Optimizer command to convert TensorFlow to OpenVINO:\")\n",
     "print(mo_command)"
@@ -262,7 +264,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/102-pytorch-onnx-to-openvino/102-pytorch-onnx-to-openvino.ipynb
+++ b/notebooks/102-pytorch-onnx-to-openvino/102-pytorch-onnx-to-openvino.ipynb
@@ -95,7 +95,6 @@
    "source": [
     "print(\"Downloading the Fastseg model (if it has not been downloaded before)....\")\n",
     "model = MobileV3Large.from_pretrained().cpu().eval()\n",
-    "model.eval()\n",
     "print(\"Loaded PyTorch Fastseg model\")\n",
     "\n",
     "# Save the model\n",
@@ -146,7 +145,7 @@
    "source": [
     "### Convert ONNX model to OpenVINO IR Format\n",
     "\n",
-    "Call the OpenVINO Model Optimizer tool to convert the ONNX model to OpenVINO IR, with FP16 precision. The models are saved to the current directory. We add the mean values to the model with `--move_to_preprocess` and scale the output with the standard deviation with `--scale_values`. With these options, it is not necessary to normalize input data before propagating it through the network.\n",
+    "Call the OpenVINO Model Optimizer tool to convert the ONNX model to OpenVINO IR, with FP16 precision. The models are saved to the current directory. We add the mean values to the model and scale the output with the standard deviation with `--scale_values`. With these options, it is not necessary to normalize input data before propagating it through the network.\n",
     "\n",
     "See the [Model Optimizer Developer Guide](https://docs.openvinotoolkit.org/latest/openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html) for more information about Model Optimizer."
    ]
@@ -162,22 +161,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Get the path to the Model Optimizer script\n",
     "mo_path = str(Path(mo_onnx.__file__))\n",
     "\n",
     "# Construct the command for Model Optimizer\n",
-    "mo_command = f\"\"\"{sys.executable} \n",
+    "mo_command = f\"\"\"\"{sys.executable}\"\n",
     "                 \"{mo_path}\" \n",
     "                 --input_model \"{onnx_path}\" \n",
     "                 --input_shape \"[1,3, 512, 1024]\" \n",
     "                 --mean_values=\"[123.675, 116.28 , 103.53]\"\n",
     "                 --scale_values=\"[58.395, 57.12 , 57.375]\"\n",
-    "                 --move_to_preprocess\n",
-    "                 --data_type FP32 \n",
-    "                 --output_dir {model_path.parent}\"\"\"\n",
+    "                 --data_type FP16\n",
+    "                 --output_dir \"{model_path.parent}\"\n",
+    "                 \"\"\"\n",
     "mo_command = \" \".join(mo_command.split())\n",
     "print(\"Model Optimizer command to convert the ONNX model to OpenVINO:\")\n",
     "print(mo_command)"
@@ -187,7 +188,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "6YUwrq7QWSzw"
+    "id": "6YUwrq7QWSzw",
+    "tags": []
    },
    "outputs": [],
    "source": [


### PR DESCRIPTION
Add quotes around sys.executable and output_dir to allow paths with spaces.
Remove `--move_to_preprocess` because that option is deprecated. Specifying means and scale moves these values to preprocess automatically (tested with ONNX notebook that output still looks the same)