### PR TITLE
Add Python 3.8 for macOS and Windows to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ The table below lists the supported operating systems and Python versions requir
 | Ubuntu\* 20.04 LTS, 64-bit                                 | 3.6, 3.7, 3.8                                        |
 | Red Hat* Enterprise Linux* 8, 64-bit                       | 3.6, 3.8                                             |
 | CentOS\* 7, 64-bit                                         | 3.6, 3.7, 3.8                                        |
-| macOS\* 10.15.x versions                                   | 3.6, 3.7                                             |
-| Windows 10\*, 64-bit Pro, Enterprise or Education editions | 3.6, 3.7                                             |
-| Windows Server\* 2016 or higher                            | 3.6, 3.7                                             |
+| macOS\* 10.15.x versions                                   | 3.6, 3.7, 3.8                                        |
+| Windows 10\*, 64-bit Pro, Enterprise or Education editions | 3.6, 3.7, 3.8                                        |
+| Windows Server\* 2016 or higher                            | 3.6, 3.7, 3.8                                        |
 
 ## 📝 Installation Guide
 


### PR DESCRIPTION
Python 3.8 for macOS and Windows is tested in the CI, so we should be able to include this in the README as well.