### PR TITLE
Fix Jupyter Lab error (#28)

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip==20.2.*
-        python -m pip install wheel
         python -m pip install -r .ci/ci-requirements.txt
         python -m ipykernel install --user --name openvino_env
         python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
@@ -38,5 +37,6 @@ jobs:
         path: pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Analysing with nbval
       run: |
+        jupyter lab notebooks --help
         python -m pytest --nbval .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,9 @@ tensorflow>=2.2
 
 # Jupyter requirements
 jupyterlab
-ipython==7.10  # pin version to prevent async warnings
 
 # Pin versions to prevent known dependency issues
 importlib-metadata==3.7.3
-numpy==1.18.5
-ipykernel==5.5.0
-
+ipython==7.10.*
+numpy==1.18.*
+setuptools>=56.0.0


### PR DESCRIPTION
Fixes `AttributeError: 'Version' object has no attribute 'major'` error when running jupyter lab

- Add setuptools to requirements.txt. See https://github.com/jupyterlab/jupyterlab/issues/10111
- Add jupyter lab --help to nbval to catch issue
- Remove ipykernel pinning since ipykernel bug has been fixed