### PR TITLE
Run nbval test on pull request only

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -1,9 +1,6 @@
 name: nbval
 
 on: 
-  push:
-    paths-ignore:
-    - '**.md'
   pull_request:
     paths-ignore:
     - '**.md'
@@ -39,4 +36,3 @@ jobs:
       run: |
         jupyter lab notebooks --help
         python -m pytest --nbval .
-


### PR DESCRIPTION
When the test is set to run at PR and push stage, it runs twice. We never push code directly to develop or main, so running the CI on PR only is enough.