### PR TITLE
Change instructions for pip install to upgrade pip

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -23,8 +23,8 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip==20.2.*
-        python -m pip install -r .ci/ci-requirements.txt
+        python -m pip install --upgrade pip
+        python -m pip install -r .ci/ci-requirements.txt --use-deprecated=legacy-resolver
         python -m ipykernel install --user --name openvino_env
         python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Archive pip freeze

--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ openvino_env\Scripts\activate
 #### Installs OpenVINO tools and dependencies like Jupyter Lab:
 
 ```bash
-# Upgrade pip to the 20.2.* version to avoid dependency issues
-python -m pip install --upgrade pip==20.2.4
-pip install -r requirements.txt
+# Upgrade pip to the latest version.
+# Use pip's legacy dependency resolver to avoid dependency conflicts
+python -m pip install --upgrade pip
+pip install -r requirements.txt --use-deprecated=legacy-resolver
 ```
 
 ### Step 5: Install the virtualenv Kernel in Jupyter


### PR DESCRIPTION
Use `--use-deprecated=legacy-resolver` with latest pip version to handle dependency conflicts instead of downgrading pip.
The danger is that pip may delete this legacy-resolver option. But hopefully we will not need this option anymore when that happens. If it does happen, we can always instruct to downgrade pip again to a version that still has this option. 
The benefit is that it is good practice to upgrade pip and this ensures that installing the requirements works when software packages are updated. This also makes the notebook work on macOS X Big Sur.

Also added new method to CI, so if it does fail at some point, the CI will catch it. 