### PR TITLE
Change Tensorflow notebook to train for 5 instead of 15 epochs

### DIFF
--- a/notebooks/103-tensorflow-training-openvino/103-tensorflow-training-openvino.ipynb
+++ b/notebooks/103-tensorflow-training-openvino/103-tensorflow-training-openvino.ipynb
@@ -849,7 +849,10 @@
    },
    "outputs": [],
    "source": [
-    "epochs = 15\n",
+    "# Increase the number of epochs to train the model for longer.\n",
+    "# Training for more epochs will likely improve the accuracy of the model.\n",
+    "# In the original TensorFlow notebook, the model is trained for 15 epochs.\n",
+    "epochs = 5\n",
     "history = model.fit(\n",
     "  train_ds,\n",
     "  validation_data=val_ds,\n",
@@ -1147,7 +1150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This decreases the time it takes to run this notebook (also in the CI).
Added message that user can increase the number of epoch for better results.
Result on demo image is still correct.