### PR TITLE
Ignore TensorFlow training in CI

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Analysing with nbval
       run: |
         jupyter lab notebooks --help
-        python -m pytest --nbval .
+        python -m pytest --nbval . --ignore notebooks/301-tensorflow-training-openvino


### PR DESCRIPTION
TensorFlow training takes too long for the CI. Temporary disabling - I will add a shorter test for this.