### PR TITLE
Ignore tensorflow training notebook in CI

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Analysing with nbval
       run: |
         jupyter lab notebooks --help
-        python -m pytest --nbval .
+        python -m pytest --nbval . --ignore notebooks/301-tensorflow-training-openvino


### PR DESCRIPTION
Temporary disable - this notebook takes too much time in CI. I will modify the CI test for this notebook later.