### PR TITLE
Add daily CI run and option to run CI manually

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -r .ci/ci-requirements.txt --use-depcrecated=legacy-resolver
+        python -m pip install -r .ci/ci-requirements.txt --use-deprecated=legacy-resolver
         python -m ipykernel install --user --name openvino_env
         python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Archive pip freeze

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -r .ci/ci-requirements.txt --use-legacy=dependency-resolver
+        python -m pip install -r .ci/ci-requirements.txt --use-depcrecated=legacy-resolver
         python -m ipykernel install --user --name openvino_env
         python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Archive pip freeze

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -1,9 +1,15 @@
 name: nbval
 
-on: 
+on:
+  workflow_dispatch:
   pull_request:
+    branches:
+    - 'develop'
+    - 'main'
     paths-ignore:
     - '**.md'
+  schedule:
+    - cron:  '30 8 * * *'
 
 jobs:
   build:

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -29,8 +29,8 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip==20.2.*
-        python -m pip install -r .ci/ci-requirements.txt
+        python -m pip install --upgrade pip
+        python -m pip install -r .ci/ci-requirements.txt --use-legacy=dependency-resolver
         python -m ipykernel install --user --name openvino_env
         python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Archive pip freeze


### PR DESCRIPTION
This update will run the CI every day (at 8:30 UTC) and adds an option to run it manually. That looks like this:
![image](https://user-images.githubusercontent.com/77325899/117963075-3d145480-b320-11eb-80b4-a82b6503ead9.png)
This works when this is merged to main.