### PR TITLE
max_retries option for video downloading in superresolution notebook

### DIFF
--- a/notebooks/202-vision-superresolution/202-vision-superresolution-video.ipynb
+++ b/notebooks/202-vision-superresolution/202-vision-superresolution-video.ipynb
@@ -330,7 +330,7 @@
     "filename = Path(\n",
     "    stream.default_filename.encode(\"ascii\", \"ignore\").decode(\"ascii\")\n",
     ").stem\n",
-    "stream.download(VIDEO_DIR, filename=filename)\n",
+    "stream.download(VIDEO_DIR, filename=filename, max_retries=2)\n",
     "print(f\"Video {filename} downloaded to {VIDEO_DIR}\")\n",
     "\n",
     "# Create Path objects for the input video and the resulting videos\n",

--- a/notebooks/202-vision-superresolution/202-vision-superresolution-video.ipynb
+++ b/notebooks/202-vision-superresolution/202-vision-superresolution-video.ipynb
@@ -330,7 +330,7 @@
     "filename = Path(\n",
     "    stream.default_filename.encode(\"ascii\", \"ignore\").decode(\"ascii\")\n",
     ").stem\n",
-    "stream.download(VIDEO_DIR, filename=filename, max_retries=2)\n",
+    "stream.download(VIDEO_DIR, filename=filename, max_retries=3, timeout=3)\n",
     "print(f\"Video {filename} downloaded to {VIDEO_DIR}\")\n",
     "\n",
     "# Create Path objects for the input video and the resulting videos\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 openvino-dev
 matplotlib<3.4
 gdown
-pytube
+pytube>=10.7
 
 # ONNX notebook requirements
 geffnet==0.9.8


### PR DESCRIPTION
YouTube downloading sometimes fails in CI. It can also fail when running a notebook manually. This PR adds a `max_retries=2` option to the YouTube download code, to make the download code a bit more robust. 

This max_retries option was added in PyTube 10.7, so I added that to the requirements. 10.7 was released beginning of April, so this will not affect existing notebook users who followed our instructions, since we added the superresolution notebook after that. If you have a not-up-to-date virtualenv, you should update PyTube. 