### PR TITLE
Temporarily ignore video superresolution notebook in CI

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -41,4 +41,4 @@ jobs:
     - name: Analysing with nbval
       run: |
         jupyter lab notebooks --help
-        python -m pytest --nbval . --ignore notebooks/301-tensorflow-training-openvino
+        python -m pytest --nbval . --ignore notebooks/301-tensorflow-training-openvino --ignore notebooks/202-vision-superresolution/202-vision-superresolution-video.ipynb


### PR DESCRIPTION
NOTE: this is a PR for the main branch.

Temporarily ignore video superresolution notebook in CI, until PyTube solution is found. This currently fails too many CI runs, making it harder to catch important errors. Superresolution is still tested in the image superresolution notebook, and video inferenceing is tested in monodepth, so ignoring this notebook should not miss critical issues. 

If we update the video superresolution notebook, we should manually test this! This really is a temporary workaround.