### PR TITLE
Use older jedi to fix the autocomplete issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,6 @@ jupyterlab
 # Pin versions to prevent known dependency issues
 importlib-metadata==3.7.3
 ipython==7.10.*
+jedi==0.17.2
 numpy==1.18.*
 setuptools>=56.0.0


### PR DESCRIPTION
A lot of `ipython` releases are affected by an incompatibility with the newest release of `jedi`. This causes exceptions when pressing tab in a notebook to use autocompletion and/or code suggestions. The issue is described here https://github.com/ipython/ipython/issues/12740 and the easiest fix is to downgrade `jedi` to 0.17