### PR TITLE
002: Add imports per section, spelling/layout updates

### DIFF
--- a/notebooks/002-openvino-api/002-openvino-api.ipynb
+++ b/notebooks/002-openvino-api/002-openvino-api.ipynb
@@ -88,7 +88,7 @@
     "\n",
     "An IR (Intermediate Representation) model consists of an .xml file, containing model information, and a .bin file, containing the weights. `read_network()` expects the weights file to be located in the same directory as the xml file, with the same filename, and the extension .bin: `model_weights_file == Path(model_xml).with_suffix(\".bin\")`. If this is the case, specifying the weights file is optional. If the weights file has a different filename, it can be specified with the `weights` parameter to `read_network()`.\n",
     "\n",
-    "See the [tensorflow-to-openvino](https://github.com/openvinotoolkit/openvino_notebooks/tree/main/notebooks/101-tensorflow-to-openvino) and [pytorch-onnx-to-openvino](https://github.com/openvinotoolkit/openvino_notebooks/tree/main/notebooks/102-pytorch-onnx-to-openvino) notebooks for information on how to convert your existing Tensorflow, PyTorch or ONNX model to OpenVINO's IR format."
+    "See the [tensorflow-to-openvino](../101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb) and [pytorch-onnx-to-openvino](../102-pytorch-onnx-to-openvino/102-pytorch-onnx-to-openvino.ipynb) notebooks for information on how to convert your existing Tensorflow, PyTorch or ONNX model to OpenVINO's IR format."
    ]
   },
   {
@@ -432,7 +432,7 @@
    "id": "4a9d2008-2a2b-4d30-837b-653a035a6315",
    "metadata": {},
    "source": [
-    "The output shape is (1,1001), which we saw is the expected shape of the output. This output shape indicates that the network returns probabilities for 1001 classes. To transform this in meaningful information, check out the [hello world notebook](../001-hello-world)."
+    "The output shape is (1,1001), which we saw is the expected shape of the output. This output shape indicates that the network returns probabilities for 1001 classes. To transform this in meaningful information, check out the [hello world notebook](../001-hello-world/001-hello-world.ipynb)."
    ]
   },
   {

--- a/notebooks/002-openvino-api/002-openvino-api.ipynb
+++ b/notebooks/002-openvino-api/002-openvino-api.ipynb
@@ -5,7 +5,7 @@
    "id": "927f9ad4-4b12-4540-b39b-4ec4b8e13e20",
    "metadata": {},
    "source": [
-    "# OpenVINO API Guide"
+    "# OpenVINO API Tutorial"
    ]
   },
   {
@@ -13,41 +13,21 @@
    "id": "bf8717c2-e593-4a40-9edc-c7cff7ad3e49",
    "metadata": {},
    "source": [
-    "This notebook explains the basics of the OpenVINO API. It currently covers:\n",
+    "This notebook explains the basics of the OpenVINO Inference Engine API. It covers:\n",
     "\n",
-    "- [Load Inference Engine and Show Info](#Load-Inference-Engine-and-show-info)\n",
-    "- [Loading a Model](#Loading-a-network)\n",
-    "  - [IR Model](#IR-model)\n",
-    "  - [ONNX Model](#ONNX-model)\n",
-    "- [Getting Information about a Model](#Getting-information-about-a-model)\n",
+    "- [Load Inference Engine and Show Info](#Load-Inference-Engine-and-Show-Info)\n",
+    "- [Loading a Model](#Loading-a-Model)\n",
+    "  - [IR Model](#IR-Model)\n",
+    "  - [ONNX Model](#ONNX-Model)\n",
+    "- [Getting Information about a Model](#Getting-Information-about-a-Model)\n",
     "  - [Model Inputs](#Model-Inputs)\n",
     "  - [Model Outputs](#Model-Outputs)\n",
-    "- [Doing Inference on a Model](#Inference)\n",
-    "- [Reshaping and Resizing](#Reshaping-a-network)\n",
-    "  - [Change Image Size](#Change-image-size)\n",
-    "  - [Change Batch Size](#Change-batch-size)\n",
+    "- [Doing Inference on a Model](#Doing-Inference-on-a-Model)\n",
+    "- [Reshaping and Resizing](#Reshaping-and-Resizing)\n",
+    "  - [Change Image Size](#Change-Image-Size)\n",
+    "  - [Change Batch Size](#Change-Batch-Size)\n",
     "    \n",
-    "The notebook is divided into sections with headers. Each section is standalone and does not depend on previous sections, with the exception of the imports in the cell below. A segmentation and classification IR model and a segmentation ONNX model are provided as examples. You can replace these model files with your own models. The exact outputs will be different, but the process is the same. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "133c8001-9c5b-4f3a-bc26-0645bf534311",
-   "metadata": {},
-   "source": [
-    "## Preparation: Imports"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8d09fe88-8f56-45a3-8536-ef55aa2a4de8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import cv2\n",
-    "import numpy as np\n",
-    "from openvino.inference_engine import IECore"
+    "The notebook is divided into sections with headers. Each section is standalone and does not depend on previous sections. A segmentation and classification IR model and a segmentation ONNX model are provided as examples. You can replace these model files with your own models. The exact outputs will be different, but the process is the same. "
    ]
   },
   {
@@ -67,6 +47,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from openvino.inference_engine import IECore\n",
+    "\n",
     "ie = IECore()"
    ]
   },
@@ -75,7 +57,7 @@
    "id": "de8e3bee-6807-469d-896e-74eabffe57f4",
    "metadata": {},
    "source": [
-    "Inference Engine can load a network on a device. A device in this context means a CPU, an Intel GPU, a Neural Compute Stick 2, etc. The `available_devices` property shows the devices that are available on your system. The \"FULL_DEVICE_NAME\" option to `ie.get_metric` shows the name of the device.\n",
+    "Inference Engine can load a network on a device. A device in this context means a CPU, an Intel GPU, a Neural Compute Stick 2, etc. The `available_devices` property shows the devices that are available on your system. The \"FULL_DEVICE_NAME\" option to `ie.get_metric()` shows the name of the device.\n",
     "\n",
     "In this notebook the CPU device is used. To use an integrated GPU, use `device_name=\"GPU\"` instead. Note that loading a network on GPU will be slower than loading a network on CPU, but inference will likely be faster."
    ]
@@ -95,22 +77,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54f280fa-0ad5-46a3-b5b4-aeae32eec5b4",
+   "id": "9f9d637e-b82c-4ddd-9bf2-2ff9bfbc00cd",
    "metadata": {},
    "source": [
     "## Loading a Model\n",
     "\n",
-    "After initializing Inference Engine, first read the model file with `read_network`, then load it to the specified device with `load_network`. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b3ad8ebe-88c0-43b2-b61f-41623bcf9a65",
-   "metadata": {},
-   "source": [
+    "After initializing Inference Engine, first read the model file with `read_network()`, then load it to the specified device with `load_network()`. \n",
+    "\n",
     "### IR Model\n",
     "\n",
-    "An IR (Intermediate Representation) model consists of an .xml file, containing model information, and a .bin file, containing the weights. `read_network` expects the weights file to be located in the same directory as the xml file, with the same filename, and the extension .bin: `model_weights_file == Path(model_xml).with_suffix(\".bin\")`. If this is the case, specifying the weights file is optional. If the weights file has a different filename, it can be specified with the `weights` parameter to `read_network`.\n",
+    "An IR (Intermediate Representation) model consists of an .xml file, containing model information, and a .bin file, containing the weights. `read_network()` expects the weights file to be located in the same directory as the xml file, with the same filename, and the extension .bin: `model_weights_file == Path(model_xml).with_suffix(\".bin\")`. If this is the case, specifying the weights file is optional. If the weights file has a different filename, it can be specified with the `weights` parameter to `read_network()`.\n",
     "\n",
     "See the [tensorflow-to-openvino](https://github.com/openvinotoolkit/openvino_notebooks/tree/main/notebooks/101-tensorflow-to-openvino) and [pytorch-onnx-to-openvino](https://github.com/openvinotoolkit/openvino_notebooks/tree/main/notebooks/102-pytorch-onnx-to-openvino) notebooks for information on how to convert your existing Tensorflow, PyTorch or ONNX model to OpenVINO's IR format."
    ]
@@ -122,6 +98,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from openvino.inference_engine import IECore\n",
+    "\n",
     "ie = IECore()\n",
     "classification_model_xml = \"classification.xml\"\n",
     "net = ie.read_network(model=classification_model_xml)\n",
@@ -145,6 +123,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from openvino.inference_engine import IECore\n",
+    "\n",
     "ie = IECore()\n",
     "onnx_model = \"segmentation.onnx\"\n",
     "net_onnx = ie.read_network(model=onnx_model)\n",
@@ -176,6 +156,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from openvino.inference_engine import IECore\n",
+    "\n",
     "ie = IECore()\n",
     "classification_model_xml = \"classification.xml\"\n",
     "net = ie.read_network(model=classification_model_xml)\n",
@@ -228,7 +210,7 @@
    "id": "2ccec019-6932-41e1-8f77-834508385dc2",
    "metadata": {},
    "source": [
-    "This cell output tells us that the model expects inputs with a shape of [1,3,224,244], and that this is NCHW layout. This means that the model expects input data with a batch size (N) of 1, 3 channels (C) and images of a height (H) and width (W) of 224. The input data is expected to be of FP32 (floating point) precision."
+    "This cell output tells us that the model expects inputs with a shape of [1,3,224,244], and that this is in NCHW layout. This means that the model expects input data with a batch size (N) of 1, 3 channels (C), and images of a height (H) and width (W) of 224. The input data is expected to be of FP32 (floating point) precision."
    ]
   },
   {
@@ -246,6 +228,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from openvino.inference_engine import IECore\n",
+    "\n",
     "ie = IECore()\n",
     "classification_model_xml = \"classification.xml\"\n",
     "net = ie.read_network(model=classification_model_xml)\n",
@@ -298,7 +282,7 @@
    "id": "ed0b7528-eb12-4389-b9b6-46ee97864e90",
    "metadata": {},
    "source": [
-    "This cell output shows that the model returns outputs with a shape of [1, 1001], where 1 is the batch size (N) and 1001 the number of classes (C). The output is returned as 32 bit floating point."
+    "This cell output shows that the model returns outputs with a shape of [1, 1001], where 1 is the batch size (N) and 1001 the number of classes (C). The output is returned as 32-bit floating point."
    ]
   },
   {
@@ -308,7 +292,7 @@
    "source": [
     "## Doing Inference on a Model\n",
     "\n",
-    "To do inference on a model, call the `infer()` method of the _ExecutableNetwork_, the `exec_net` that we loaded with `load_network`. `infer()` expects one argument: _inputs_. This is a dictionary, mapping input layer names to input data."
+    "To do inference on a model, call the `infer()` method of the _ExecutableNetwork_, the `exec_net` that we loaded with `load_network()`. `infer()` expects one argument: _inputs_. This is a dictionary, mapping input layer names to input data."
    ]
   },
   {
@@ -326,6 +310,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from openvino.inference_engine import IECore\n",
+    "\n",
     "ie = IECore()\n",
     "classification_model_xml = \"classification.xml\"\n",
     "net = ie.read_network(model=classification_model_xml)\n",
@@ -341,7 +327,7 @@
    "source": [
     "**Preparation: load image and convert to input shape**\n",
     "\n",
-    "To propagate an image to the network, it needs to be loaded, resized to the shape that the network expects, and converted to the layout that the network expects."
+    "To propagate an image through the network, it needs to be loaded into an array, resized to the shape that the network expects, and converted to the network's input layout."
    ]
   },
   {
@@ -351,6 +337,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import cv2\n",
+    "\n",
     "image_filename = \"coco_hollywood.jpg\"\n",
     "image = cv2.imread(image_filename)\n",
     "image.shape"
@@ -361,9 +349,7 @@
    "id": "6e4e1c12-913d-469a-bdcd-974f5d7e7da7",
    "metadata": {},
    "source": [
-    "The image has a shape of (664,994,3). It is 663 pixels in height, 994 pixels in width, and has 3 color channels. \n",
-    "\n",
-    "We get a reference to the height and width that the network expects, and resize to that size"
+    "The image has a shape of (664,994,3). It is 663 pixels in height, 994 pixels in width, and has 3 color channels. We get a reference to the height and width that the network expects and resize to that size"
    ]
   },
   {
@@ -374,18 +360,10 @@
    "outputs": [],
    "source": [
     "# N,C,H,W = batch size, number of channels, height, width\n",
-    "N, C, H, W = net.input_info[input_layer].tensor_desc.dims"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "682be1dc-dcae-49df-afed-d5fcadd8e43f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "resized_image = cv2.resize(src=image, dsize=(W, H))  # OpenCV resize expects the destination size as (width, height)\n",
-    "print(f\"resized image shape: {resized_image.shape}\")"
+    "N, C, H, W = net.input_info[input_layer].tensor_desc.dims\n",
+    "# OpenCV resize expects the destination size as (width, height)\n",
+    "resized_image = cv2.resize(src=image, dsize=(W, H))\n",
+    "resized_image.shape"
    ]
   },
   {
@@ -393,7 +371,7 @@
    "id": "b9355a90-24ee-4792-ba8f-0b347f491bb2",
    "metadata": {},
    "source": [
-    "Now the image has the width and height that the network expects. It is still in H,C,W format, we change it to N,C,H,W format (where N=1) by first calling `np.transpose` to change to C,H,W and then adding the N dimension by calling `np.expand_dims`. Convert the data to FP32 with `np.astype()`."
+    "Now the image has the width and height that the network expects. It is still in H,C,W format. We change it to N,C,H,W format (where N=1) by first calling `np.transpose()` to change to C,H,W and then adding the N dimension by calling `np.expand_dims()`. Convert the data to FP32 with `np.astype()`."
    ]
   },
   {
@@ -403,6 +381,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
+    "\n",
     "input_data = np.expand_dims(np.transpose(resized_image, (2, 0, 1)), 0).astype(np.float32)\n",
     "input_data.shape"
    ]
@@ -452,7 +432,7 @@
    "id": "4a9d2008-2a2b-4d30-837b-653a035a6315",
    "metadata": {},
    "source": [
-    "The output shape is (1,1001), which we saw is indeed the expected shape of the output. This output shape indicates that the network returns probabilities for 1001 classes. To transform this in meaningful information, check out the [hello world notebook](../001-hello-world)."
+    "The output shape is (1,1001), which we saw is the expected shape of the output. This output shape indicates that the network returns probabilities for 1001 classes. To transform this in meaningful information, check out the [hello world notebook](../001-hello-world)."
    ]
   },
   {
@@ -470,50 +450,50 @@
    "id": "185266c4-f599-4ddb-a594-c6b19554c67b",
    "metadata": {},
    "source": [
-    "Instead of reshaping the image to fit the model, you can also reshape the model to fit the image. Note that not all input shapes will work for every model, and the model accuracy may also suffer if you reshape the model inputs."
+    "Instead of reshaping the image to fit the model, you can also reshape the model to fit the image. Note that not all models support reshaping, and models that do may not support all input shapes. The model accuracy may also suffer if you reshape the model input shape.\n",
+    "\n",
+    "We first check the input shape of the model, and then reshape to the new input shape."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "976be688-7277-4b20-b5cf-df815140fee1",
+   "id": "9d82321a-9032-4a66-b961-459812d26247",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from openvino.inference_engine import IECore\n",
+    "\n",
     "ie = IECore()\n",
     "segmentation_model_xml = \"segmentation.xml\"\n",
     "segmentation_net = ie.read_network(model=segmentation_model_xml)\n",
     "segmentation_input_layer = next(iter(segmentation_net.input_info))\n",
     "segmentation_output_layer = next(iter(segmentation_net.outputs))\n",
     "\n",
-    "print(f\"input shape: {segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims}\")\n",
+    "print(\"~~~~ ORIGINAL MODEL ~~~~\")\n",
     "print(f\"input layout: {segmentation_net.input_info[segmentation_input_layer].layout}\")\n",
+    "print(f\"input shape: {segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims}\")\n",
+    "print(f\"output shape: {segmentation_net.outputs[segmentation_output_layer].shape}\")\n",
+    "\n",
+    "new_shape = (1, 3, 544, 544)\n",
+    "segmentation_net.reshape({segmentation_input_layer: new_shape})\n",
+    "segmentation_exec_net = ie.load_network(network=segmentation_net, device_name=\"CPU\")\n",
+    "\n",
+    "print(\"~~~~ RESHAPED MODEL ~~~~\")\n",
+    "print(f\"net input shape: {segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims}\")\n",
+    "print(\n",
+    "    f\"exec_net input shape: \"\n",
+    "    f\"{segmentation_exec_net.input_info[segmentation_input_layer].tensor_desc.dims}\"\n",
+    ")\n",
     "print(f\"output shape: {segmentation_net.outputs[segmentation_output_layer].shape}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bb66d427-6682-4a90-8f0b-d4ade2731843",
+   "id": "82c85d12-7c52-4b1f-bc18-0971702954ee",
    "metadata": {},
    "source": [
-    "The input shape for the segmentation network is [1,3,256,256], with NHCW layout: the network expects 3-channel images with width and height of 512 and a batch size of 1. We can reshape the network to make it accept input images with width and height of 544 with the `.reshape()` method of `IENetwork`. This segmentation network always returns arrays with the same shape as the input shape, so setting the input shape to 544x544 also modifies the output shape. After reshaping, load the network to the device again."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7b542ccf-4375-4e22-9428-610219fc9551",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "new_shape = (1, 3, 544, 544)\n",
-    "\n",
-    "segmentation_net.reshape({segmentation_input_layer: new_shape})\n",
-    "segmentation_exec_net = ie.load_network(network=segmentation_net, device_name=\"CPU\")\n",
-    "print(f\"net input shape: {segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims}\")\n",
-    "print(f\"exec_net input shape: \" \n",
-    "      f\"{segmentation_exec_net.input_info[segmentation_input_layer].tensor_desc.dims}\")\n",
-    "print(f\"output shape: {segmentation_net.outputs[segmentation_output_layer].shape}\")"
+    "The input shape for the segmentation network is [1,3,512,512], with an NHCW layout: the network expects 3-channel images with a width and height of 512 and a batch size of 1. We reshape the network to make it accept input images with a width and height of 544 with the `.reshape()` method of `IENetwork`. This segmentation network always returns arrays with the same width and height as the input width and height, so setting the input dimensions to 544x544 also modifies the output dimensions. After reshaping, load the network to the device again."
    ]
   },
   {
@@ -529,7 +509,7 @@
    "id": "d96c8686-961e-4a77-80fb-5c2b2d9d84b5",
    "metadata": {},
    "source": [
-    "We can also use reshape to set the batch size, by increasing the first element of _new_shape_. For example, to set a batch size of two, set `new_shape = (2,3,544,544)` in the cell above. If you only want to change the batch size, you can also set the `batch_size` property directly. "
+    "We can also use `.reshape()` to set the batch size, by increasing the first element of _new_shape_. For example, to set a batch size of two, set `new_shape = (2,3,544,544)` in the cell above. If you only want to change the batch size, you can also set the `batch_size` property directly. "
    ]
   },
   {
@@ -539,6 +519,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from openvino.inference_engine import IECore\n",
+    "\n",
     "ie = IECore()\n",
     "segmentation_model_xml = \"segmentation.xml\"\n",
     "segmentation_net = ie.read_network(model=segmentation_model_xml)\n",
@@ -546,8 +528,9 @@
     "segmentation_output_layer = next(iter(segmentation_net.outputs))\n",
     "segmentation_net.batch_size = 2\n",
     "segmentation_exec_net = ie.load_network(network=segmentation_net, device_name=\"CPU\")\n",
-    "print(f\"input shape: {segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims}\")\n",
+    "\n",
     "print(f\"input layout: {segmentation_net.input_info[segmentation_input_layer].layout}\")\n",
+    "print(f\"input shape: {segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims}\")\n",
     "print(f\"output shape: {segmentation_net.outputs[segmentation_output_layer].shape}\")"
    ]
   },
@@ -556,7 +539,7 @@
    "id": "c74461f1-cd6c-42d9-9e1f-bdfd64999ade",
    "metadata": {},
    "source": [
-    "Notice that the output above shows that by setting the batch size, the output shape now shows a batch size of 2 indeed. Let's see what happens if we propagate our input image through the network:"
+    "The output shows that by setting the batch size to 2, the first element (N) of the input and output shape now has a value of 2. Let's see what happens if we propagate our input image through the network:"
    ]
   },
   {
@@ -566,6 +549,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
+    "from openvino.inference_engine import IECore\n",
+    "\n",
     "ie = IECore()\n",
     "segmentation_model_xml = \"segmentation.xml\"\n",
     "segmentation_net = ie.read_network(model=segmentation_model_xml)\n",
@@ -574,10 +560,10 @@
     "input_data = np.random.rand(*segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims)\n",
     "segmentation_net.batch_size = 2\n",
     "segmentation_exec_net = ie.load_network(network=segmentation_net, device_name=\"CPU\")\n",
-    "\n",
     "result_batch = segmentation_exec_net.infer({segmentation_input_layer: input_data})\n",
+    "\n",
     "print(f\"input data shape: {input_data.shape}\")\n",
-    "print(f\"output data shape: {result_batch[segmentation_output_layer].shape}\")"
+    "print(f\"result data data shape: {result_batch[segmentation_output_layer].shape}\")"
    ]
   },
   {
@@ -585,9 +571,9 @@
    "id": "39203162-8544-48b0-a182-00c053541d24",
    "metadata": {},
    "source": [
-    "The output of the cell above shows that the if the batch size is 2, the network output will have a batch size of 2, even if only one image was propagated through the network. Regardless of batch size, you can always do inference on 1 image. In that case, only the first network output contains meaningful information.\n",
+    "The output shows that the if the batch size is 2, the network output will have a batch size of 2, even if only one image was propagated through the network. Regardless of batch size, you can always do inference on one image. In that case, only the first network output contains meaningful information.\n",
     "\n",
-    "Verify that inference on two images works, by creating random data with a batch size of 2:"
+    "Verify that inference on two images works by creating random data with a batch size of 2:"
    ]
   },
   {
@@ -597,6 +583,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
+    "from openvino.inference_engine import IECore\n",
+    "\n",
     "ie = IECore()\n",
     "segmentation_model_xml = \"segmentation.xml\"\n",
     "segmentation_net = ie.read_network(model=segmentation_model_xml)\n",
@@ -605,10 +594,10 @@
     "segmentation_net.batch_size = 2\n",
     "input_data = np.random.rand(*segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims)\n",
     "segmentation_exec_net = ie.load_network(network=segmentation_net, device_name=\"CPU\")\n",
-    "\n",
     "result_batch = segmentation_exec_net.infer({segmentation_input_layer: input_data})\n",
+    "\n",
     "print(f\"input data shape: {input_data.shape}\")\n",
-    "print(f\"output data shape: {result_batch[segmentation_output_layer].shape}\")"
+    "print(f\"result data shape: {result_batch[segmentation_output_layer].shape}\")"
    ]
   }
  ],


### PR DESCRIPTION
The name change from Guide to Tutorial was not merged in the previous PR. Changed that and added per-section imports. Most cells work with just the OpenVINO import, others only need either numpy or cv2. For this kind of tutorial, I think it is nice to be able to quickly see a complete example without having to scroll up for the exact imports.

Also improved spelling/phrasing a bit and merged a few cells. 