### PR TITLE
Test requirements install

### DIFF
--- a/.github/workflows/install_requirements.yml
+++ b/.github/workflows/install_requirements.yml
@@ -1,0 +1,37 @@
+name: install_requirements
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '30 14 * * *'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
+        python: [3.6, 3.7, 3.8]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r .ci/dev-requirements.txt --use-deprecated=legacy-resolver
+        python -m ipykernel install --user --name openvino_env
+        python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
+    - name: Archive pip freeze
+      uses: actions/upload-artifact@v2
+      with:
+        name: pip-freeze
+        path: pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
+    - name: Test that `jupyter lab` works
+      run: |
+        jupyter lab notebooks --help

--- a/.github/workflows/install_requirements.yml
+++ b/.github/workflows/install_requirements.yml
@@ -2,8 +2,6 @@ name: install_requirements
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '30 14 * * *'
 
 jobs:
   build:

--- a/.github/workflows/install_requirements_china.yml
+++ b/.github/workflows/install_requirements_china.yml
@@ -1,0 +1,38 @@
+name: install_requirements
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '30 18 * * *'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
+        python: [3.6, 3.7, 3.8]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt --use-deprecated=legacy-resolver -i https://pypi.tuna.tsinghua.edu.cn/simple
+
+        python -m ipykernel install --user --name openvino_env
+        python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
+    - name: Archive pip freeze
+      uses: actions/upload-artifact@v2
+      with:
+        name: pip-freeze
+        path: pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
+    - name: Test that `jupyter lab` works
+      run: |
+        jupyter lab notebooks --help

--- a/.github/workflows/install_requirements_china.yml
+++ b/.github/workflows/install_requirements_china.yml
@@ -1,4 +1,4 @@
-name: install_requirements
+name: install_requirements_china
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Add a test to check that installation of requirements works. This is part of the regular nbval test, but useful if you just want to check manually whether there are problems with installation.
Also added separate check to see that installation with the mirror in the instructions for China still works. Not a perfect test, since we will not be testing from within China, but better than nothing. This test runs daily. 