### PR TITLE
Add installation and launch script, with tests

### DIFF
--- a/.ci/utils.py
+++ b/.ci/utils.py
@@ -1,0 +1,26 @@
+def check_jupyter_running():
+    """
+    Check that Jupyter Lab is running. Raises ValueError if not. This is a utility function 
+    for the CI. It is not suitable for use outside of the CI.
+    """
+    import psutil
+    for item in psutil.process_iter():
+        if "python" in item.name():
+            print(item.cmdline())
+            if len([line for line in item.cmdline() if "jupyterlab" in line]) > 0:
+                # Jupyter found in list of running processes: return without error
+                return
+    raise RuntimeError("Jupyter Lab is not running")
+
+def check_install_output():
+    """
+    Check that the check_install.py script shows "Everything looks good"
+    """
+    import subprocess
+    import sys
+    pythonpath = sys.executable
+    print(pythonpath)
+    result = subprocess.run([pythonpath, "check_install.py"], capture_output=True, universal_newlines=True, shell=True)
+    print(result.stdout)
+    if not "Everything looks good" in result.stdout:
+        raise RuntimeError("check_install failed")

--- a/.github/workflows/install_launch.yml
+++ b/.github/workflows/install_launch.yml
@@ -1,0 +1,47 @@
+name: install_launch
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/install_launch.yml"
+      - "install_notebooks.py"
+      - "launch_notebooks.py"
+      - ".ci/utils.py"
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
+        python: [3.7,]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install notebooks
+      run: |
+        python install_notebooks.py -y
+    - name: Launch notebooks (Unix)
+      run: |
+        pip install psutil nbval
+        nohup python launch_notebooks.py --no-browser &
+      if: matrix.os != 'windows-latest'
+    - name: Launch notebooks (Windows)
+      run: |
+        pip install psutil nbval
+        pythonw launch_notebooks.py --no-browser 
+      if: matrix.os == 'windows-latest'
+    - name: Check jupyter running
+      run: |
+        python -c "import sys,time;sys.path.append('.ci');time.sleep(5);import utils;utils.check_jupyter_running()"
+      if: matrix.os != 'windows-latest'
+    - name: Test Hello World
+      run: |
+        python -m pytest --nbval notebooks/001-hello-world/001-hello-world.ipynb

--- a/install_notebooks.py
+++ b/install_notebooks.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# This script installs the OpenVINO notebooks in an openvino_env
+# virtual environment. If an openvino_env directory exists in the
+# current directory, the notebooks will be installed there. If not,
+# a new virtualenv will be created there.
+#
+# The script is tested on Windows, macOS and Ubuntu 18.04 and 20.04. It may
+# not work on every system though. If there are errors, please follow the
+# instructions on https://github.com/openvinotoolkit/openvino_notebooks to
+# install the notebooks manually. If you find a bug or issue, please report
+# it at https://github.com/openvinotoolkit/openvino_notebooks/issues
+# Suggestions are welcome at
+# https://github.com/openvinotoolkit/openvino_notebooks/discussions
+
+
+import subprocess
+import sys
+from pathlib import Path
+import os
+
+pythonpath = sys.executable
+curdir = Path(__file__).parent.resolve()
+parentdir = curdir.parent
+
+scripts_dir = "Scripts" if sys.platform == "win32" else "bin"
+
+# -----------------------------------------------------------------------#
+# Check for supported python version.                                    #
+# -----------------------------------------------------------------------#
+
+PYTHON_VERSION = sys.version_info
+SUPPORTED_PYTHON_VERSION = PYTHON_VERSION.major == 3 and (
+    PYTHON_VERSION.minor >= 6 and PYTHON_VERSION.minor <= 8
+)
+
+if not SUPPORTED_PYTHON_VERSION:
+    error_message = f"Python {PYTHON_VERSION.major}.{PYTHON_VERSION.minor} is not currently " \
+                    "supported by OpenVINO.\n" \
+                    "Please install python 3.6, 3.7, or 3.8."
+
+    if sys.platform == "win32":
+        error_message += "\nIf you used the python.org installer to install multiple versions\n" \
+                         "of Python, you can choose a specific version with `py`\n" \
+                         "For example, type: `py -3.7 install_notebooks.py`"
+    else:
+        error_message += "\nIf you installed multiple versions of python, call this script \n" \
+                         "with the path to the Python executable. For example: \n" \
+                         "`/usr/bin/python3.7` install_notebooks.py"
+    print(error_message)
+    sys.exit()
+
+
+# -----------------------------------------------------------------------#
+# Check for confirmation to install notebooks                            #
+# -----------------------------------------------------------------------#
+
+
+if "-y" not in sys.argv:
+    agree = input("OpenVINO notebook requirements will be installed in "
+                  "an 'openvino_env' environment in the current directory.\n"
+                  "The environment will be created if it does not exist. Do "
+                  "you want to continue? [Y/N]\n")
+    if agree.upper() != "Y":
+        sys.exit()
+
+# -----------------------------------------------------------------------#
+# If openvino_env exists in the current directory, try to install there. #
+# If openvino_env does not exist, create it.                             #
+# -----------------------------------------------------------------------#
+
+if "openvino_env" not in pythonpath:
+    dirlist = [item.name for item in Path(".").iterdir()]
+
+    if "openvino_env" not in dirlist:
+        print("Creating openvino_env virtualenv...")
+        subprocess.run([pythonpath, "-m", "venv", "openvino_env"])
+        print("openvino_env created.")
+    pythonpath = os.path.normpath(os.path.join(curdir, f"openvino_env/{scripts_dir}/python"))
+
+try:
+    print("Upgrading pip...")
+    subprocess.run([pythonpath, "-m", "pip", "install", "--upgrade", "pip"], shell=False)
+    print("Installing all requirements. This may take a while...")
+    subprocess.run([pythonpath, "-m", "pip", "install", "--upgrade", "-r", "requirements.txt",
+                    "--use-deprecated", "legacy-resolver"], shell=False)
+    subprocess.run([pythonpath, "-m", "ipykernel", "install", "--user", "--name", "openvino_env"])
+except Exception as e:
+    print("\nInstallation failed. Please follow the instructions on "
+          "https://github.com/openvinotoolkit/openvino_notebooks\n"
+          "to install the notebooks manually. The error message is:")
+    print(e)
+else:
+    print("\nInstallation succeeded! You can launch the notebooks with "
+          "`python launch_notebooks.py`")

--- a/launch_notebooks.py
+++ b/launch_notebooks.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# This script launches the OpenVINO notebooks. The notebooks must be
+# installed first. To do this, run `python install_notebooks.py` or follow the
+# instructions on https://github.com/openvinotoolkit/openvino_notebooks
+#
+# The script is tested on Windows, macOS and Ubuntu 18.04 and 20.04. It may
+# not work on every system though. If there are errors, please
+# launch the notebooks manually by activating the virtual environment
+# and typing `jupyter lab notebooks` in the directory that contains this
+# script.
+
+
+import subprocess
+import sys
+from pathlib import Path
+import os
+
+
+pythonpath = sys.executable
+curdir = Path(__file__).parent.resolve()
+parentdir = curdir.parent
+
+command_line_args = sys.argv[1:]
+
+# If openvino_env is already activated, launch jupyter lab
+# This will also start if openvino_env_2 is activated instead of openvino_env
+# The assumption is that that is usually intended
+if "openvino_env" in pythonpath:
+    subprocess.run([pythonpath, "-m", "jupyterlab", "notebooks", *command_line_args])
+else:
+    if sys.platform == "win32":
+        scripts_dir = "Scripts"
+    else:
+        scripts_dir = "bin"
+
+    # If openvino_env is not activated, search for the openvino_env folder in the
+    # current and parent directory and launch the notebooks
+    try:
+        pythonpath = os.path.normpath(
+            os.path.join(curdir, f"openvino_env/{scripts_dir}/python")
+        )
+        subprocess.run([pythonpath, "-m", "jupyterlab", "notebooks", *command_line_args])
+    except:
+        try:
+            pythonpath = os.path.normpath(
+                os.path.join(parentdir, f"openvino_env/{scripts_dir}/python")
+            )
+            subprocess.run([pythonpath, "-m", "jupyterlab", "notebooks", *command_line_args])
+        except SyntaxError:
+            subprocess.run([pythonpath, "-m", "jupyterlab", "notebooks"])
+        except:
+            print(pythonpath)
+            print(
+                "openvino_env could not be found in the current or parent "
+                "directory, or the installation is not complete. Please follow "
+                "the instructions on "
+                "https://github.com/openvinotoolkit/openvino_notebooks to "
+                "install the notebook requirements in a virtual environment.\n\n"
+                "After installation, you can also launch the notebooks by "
+                "activating the virtual environment manually (see the README "
+                "on GitHub, linked above) and typing `jupyter lab notebooks`.\n\n"
+                f"Current directory: {curdir}"
+                f"Python executable: {sys.executable}"
+            )


### PR DESCRIPTION
install_notebooks.py installs the notebook in a virtualenv in the current directory. launch_notebooks.py launches the notebooks from the virtualenv in the current directory or the parent directory. 

Added a test to verify that the install works. Did not add anything about the install_notebooks.py script to the README yet - not sure if we want to mention this as a recommended method already. 