### PR TITLE
Add test for docker build (Ubuntu only)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,23 @@
+name: docker_build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - ".openshift/*"
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Docker image
+      run: |
+        docker build .


### PR DESCRIPTION
Add CI test to check that `docker build .` works. Will need to make a better test for this and include the image in CI tests and test the notebooks. This also only tests docker build on Ubuntu for now - but it at least verifies that there are no breaking issues in the Dockerfile.