### PR TITLE
Remove comparison with PaddleGAN model from notebook

### DIFF
--- a/notebooks/206-vision-paddlegan-anime/206-vision-paddlegan-anime.ipynb
+++ b/notebooks/206-vision-paddlegan-anime/206-vision-paddlegan-anime.ipynb
@@ -494,7 +494,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Step 1. Load the image and convert to RGB\n",
+    "# Step 1. Load an image and convert to RGB\n",
+    "image_path = Path(\"coco_bricks.png\")\n",
     "image = cv2.cvtColor(cv2.imread(str(image_path), flags=cv2.IMREAD_COLOR), cv2.COLOR_BGR2RGB)\n",
     "\n",
     "# Step 2. Transform the image (only resize and transpose are still required)\n",
@@ -536,13 +537,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(1, 3, figsize=(25, 15))\n",
+    "fig, ax = plt.subplots(1, 2, figsize=(25, 15))\n",
     "ax[0].imshow(image)\n",
-    "ax[1].imshow(result_image_pg)\n",
-    "ax[2].imshow(result_image_ir)\n",
+    "ax[1].imshow(result_image_ir)\n",
     "ax[0].set_title(\"Image\")\n",
-    "ax[1].set_title(\"PaddleGAN result\")\n",
-    "ax[2].set_title(\"OpenVINO IR result\");"
+    "ax[1].set_title(\"OpenVINO IR result\");"
    ]
   },
   {


### PR DESCRIPTION
PaddleGAN inference is slow, and the comparison requires running the entire notebook from the start. Now you can change the image path (in the cell itself) and do inference on a new image. To compare the output a user can scroll up, or compare the saved anime images. 