### PR TITLE
2021.4

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -r .ci/dev-requirements.txt --use-deprecated=legacy-resolver
+        python -m pip install -r .ci/dev-requirements.txt
         python -m ipykernel install --user --name openvino_env
         python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Archive pip freeze

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Upgrade pip to the latest version. Use pip's legacy dependency resolver to avoid
 
 ```bash
 python -m pip install --upgrade pip
-pip install -r requirements.txt --use-deprecated=legacy-resolver
+pip install -r requirements.txt
 python -m ipykernel install --user --name openvino_env
 ```
 

--- a/notebooks/101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb
+++ b/notebooks/101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb
@@ -110,8 +110,7 @@
     "# Run Model Optimizer if the IR model file does not exist\n",
     "if not ir_path.exists():\n",
     "    print(\"Exporting TensorFlow model to IR... This may take a few minutes.\")\n",
-    "    mo_result = %sx $mo_command\n",
-    "    print(\"\\n\".join(mo_result))\n",
+    "    ! $mo_command\n",
     "else:\n",
     "    print(f\"IR model {ir_path} already exists.\")"
    ]

--- a/notebooks/101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb
+++ b/notebooks/101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb
@@ -110,7 +110,8 @@
     "# Run Model Optimizer if the IR model file does not exist\n",
     "if not ir_path.exists():\n",
     "    print(\"Exporting TensorFlow model to IR... This may take a few minutes.\")\n",
-    "    ! $mo_command\n",
+    "    mo_result = %sx $mo_command\n",
+    "    print(\"\\n\".join(mo_result))\n",
     "else:\n",
     "    print(f\"IR model {ir_path} already exists.\")"
    ]
@@ -269,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/102-pytorch-onnx-to-openvino/102-pytorch-onnx-to-openvino.ipynb
+++ b/notebooks/102-pytorch-onnx-to-openvino/102-pytorch-onnx-to-openvino.ipynb
@@ -213,7 +213,8 @@
    "source": [
     "if not ir_path.exists():\n",
     "    print(\"Exporting ONNX model to IR... This may take a few minutes.\")\n",
-    "    ! $mo_command\n",
+    "    mo_result = %sx $mo_command\n",
+    "    print(\"\\n\".join(mo_result))\n",
     "else:\n",
     "    print(f\"IR model {ir_path} already exists.\")"
    ]

--- a/notebooks/205-vision-background-removal/205-vision-background-removal.ipynb
+++ b/notebooks/205-vision-background-removal/205-vision-background-removal.ipynb
@@ -303,7 +303,8 @@
    "source": [
     "if not ir_path.exists():\n",
     "    print(\"Exporting ONNX model to IR... This may take a few minutes.\")\n",
-    "    ! $mo_command\n",
+    "    mo_result = %sx $mo_command\n",
+    "    print(\"\\n\".join(mo_result))\n",
     "else:\n",
     "    print(f\"IR model {ir_path} already exists.\")"
    ]
@@ -542,7 +543,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino-pot.ipynb
+++ b/notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino-pot.ipynb
@@ -35,6 +35,7 @@
     "\n",
     "if not \"2021.4\" in openvino.inference_engine.get_version():\n",
     "    print(\"Installing OpenVINO 2021.4. This may take a while...\")\n",
+    "    print(\"It is recommended to restart the Jupyter Kernel after installation, with Kernel->Restart Kernel\")\n",
     "    install_result = %sx python -m pip install --upgrade openvino-dev==2021.4\n",
     "    install_result = [line for line in install_result if not \"Requirement already satisfied\" in line]\n",
     "    print(\"\\n\".join(install_result))\n",

--- a/notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino.ipynb
+++ b/notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino.ipynb
@@ -93,27 +93,13 @@
     "import mo_tf\n",
     "from openvino.inference_engine import IECore\n",
     "\n",
+    "# Enable oneDNN CPU performance optimizations in TensorFlow for faster training on Intel CPUs\n",
+    "os.environ['TF_ENABLE_ONEDNN_OPTS'] = '1'\n",
+    "\n",
     "import tensorflow as tf\n",
     "from tensorflow import keras\n",
     "from tensorflow.keras import layers\n",
     "from tensorflow.keras.models import Sequential"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Enable Intel® oneAPI Deep Neural Network Library (oneDNN) Optimizations\n",
-    "This enables oneDNN CPU performance optimizations in TensorFlow for faster training on Intel CPUs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "os.environ['TF_ENABLE_ONEDNN_OPTS'] = '1'"
    ]
   },
   {

--- a/notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino.ipynb
+++ b/notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino.ipynb
@@ -99,7 +99,7 @@
     "from tensorflow.keras.models import Sequential"
    ]
   },
-    {
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1035,7 +1035,8 @@
    "source": [
     "# Run the Model Optimizer (overwrites the older model)\n",
     "print(\"Exporting TensorFlow model to IR... This may take a few minutes.\")\n",
-    "!$mo_command"
+    "mo_result = %sx $mo_command\n",
+    "print(\"\\n\".join(mo_result))"
    ]
   },
   {
@@ -1166,7 +1167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ torch>=1.5.1+cpu,<=1.7.1+cpu; sys_platform =='linux' or platform_system == 'Wind
 torchvision>=0.6.1+cpu,<=0.8.2+cpu; sys_platform =='linux' or platform_system == 'Windows'
 
 # Tensorflow notebook requirements
+tensorflow==2.5.*
 networkx>=1.11
 defusedxml>=0.5.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openvino-dev
+openvino-dev==2021.4
 matplotlib<3.4
 gdown
 pytube
@@ -18,14 +18,11 @@ torchvision>=0.6.1+cpu,<=0.8.2+cpu; sys_platform =='linux' or platform_system ==
 # Tensorflow notebook requirements
 networkx>=1.11
 defusedxml>=0.5.0
-tensorflow>=2.2,<2.4
 
 # Jupyter requirements
 jupyterlab
 
 # Pin versions to prevent known dependency issues
-importlib-metadata==3.7.3
 ipython==7.10.*
 jedi==0.17.2
-numpy==1.18.*
 setuptools>=56.0.0


### PR DESCRIPTION
- use %sx instead of ! for some notebooks
-  remove deprecated legacy resolver from pip install
- remove version pinnings for numpy and importlib-metadata
- pin tensorflow to 2.5