### PR TITLE
Markdown and HTML conversion in CI

### DIFF
--- a/.ci/convert_notebooks.sh
+++ b/.ci/convert_notebooks.sh
@@ -1,0 +1,14 @@
+# Execute notebooks and convert them to Markdown and HTML
+
+htmldir=$PWD"/html_files"
+markdowndir=$PWD"/markdown_files"
+mkdir -p $htmldir
+mkdir -p $markdowndir
+
+git ls-files "*.ipynb" | while read notebook; do
+    executed_notebook=${notebook/.ipynb/-with-output.ipynb}
+    echo $executed_notebook
+    jupyter nbconvert --execute --to notebook --output $executed_notebook --output-dir . --ExecutePreprocessor.kernel_name="python3" $notebook 
+    jupyter nbconvert --to markdown $executed_notebook --output-dir $markdowndir
+    jupyter nbconvert --to html $executed_notebook --output-dir $htmldir
+done

--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -1,0 +1,43 @@
+# Execute notebooks and convert them to Markdown and HTML
+
+name: Convert Notebooks
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r .ci/ci-requirements.txt
+        python -m pip freeze > pip-freeze.txt
+    - name: Archive pip freeze
+      uses: actions/upload-artifact@v2
+      with:
+        name: pip-freeze
+        path: pip-freeze.txt
+    - name: Modify Notebooks
+      # Change settings in slower notebooks to speed up notebook execution
+      run: |
+        sed -i 's/NUM_FRAMES = 100/NUM_FRAMES = 5/g' notebooks/202-vision-superresolution/202-vision-superresolution-video.ipynb
+        sed -i 's/epochs = 15/epochs = 2/g' notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino.ipynb
+    - name: convert_notebooks
+      run: bash .ci/convert_notebooks.sh
+    - name: Save HTML files
+      uses: actions/upload-artifact@v2
+      with:
+        name: html_files
+        path: html_files
+    - name: Save Markdown files
+      uses: actions/upload-artifact@v2
+      with:
+        name: markdown_files
+        path: markdown_files

--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
     - 'main'
-  paths:
+    paths:
     - "**.ipynb"
 jobs:
   build:

--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -3,6 +3,11 @@
 name: Convert Notebooks
 on:
   workflow_dispatch:
+  push:
+    branches:
+    - 'main'
+  paths:
+    - "**.ipynb"
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Add CI task to convert notebooks to Markdown and HTML. Notebooks are executed and then converted, so outputs are included. The CI task runs on every push to main of notebook files, and can also be run manually. To download the files (once this PR is merged), go to the Actions page, click on "Convert Notebooks", select the most recent run (the top one), and download the files. See https://github.com/helena-intel/openvino_notebooks/actions/runs/1001654885 for an example. 
![image](https://user-images.githubusercontent.com/77325899/124497516-3bfd2200-ddbb-11eb-9e9d-a4d051da3fc0.png)

This is not meant for publishing but for testing. I modified the notebooks slightly to make execution much faster and reduce size of the files: the number of frames to inference in superresolution is reduced and the number of epochs in tensorflow training is set to 1.