### PR TITLE
Only run nbval tests if notebook or python files changed

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -8,6 +8,8 @@ on:
     paths:
     - 'notebooks/**.ipynb'
     - 'notebooks/**.py'
+    - 'requirements.txt'
+    - '.ci/*requirements.txt'
   schedule:
     - cron:  '30 8 * * *'
 

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -5,8 +5,9 @@ on:
   pull_request:
     branches:
     - 'main'
-    paths-ignore:
-    - '**.md'
+    paths:
+    - 'notebooks/**.ipynb'
+    - 'notebooks/**.py'
   schedule:
     - cron:  '30 8 * * *'
 


### PR DESCRIPTION
It is not necessary to run nbval after changing a Dockerfile or a workflow file. Instead of specifying which paths to ignore (as we do now), this PR specifies which paths to include. nbval will run automatically only if notebook (.ipynb) or python (.py) files are changed in a PR.