### PR TITLE
pin ipykernel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ ipython==7.10.*
 jedi==0.17.2
 setuptools>=56.0.0
 Pillow==8.2.*
+ipykernel==5.*


### PR DESCRIPTION
ipykernel 6 is out and may be pulled in by other dependencies. pin to 5.* to prevent issues. 