### PR TITLE
Make AnimeGAN inference optional on PaddlePaddle model

### DIFF
--- a/notebooks/206-vision-paddlegan-anime/206-vision-paddlegan-anime.ipynb
+++ b/notebooks/206-vision-paddlegan-anime/206-vision-paddlegan-anime.ipynb
@@ -190,7 +190,7 @@
     "6. optionally adjusts the brightness of the result image\n",
     "7. saves the image\n",
     "\n",
-    "We can execute these steps manually and confirm that the result looks correct. To speed up inference time, resize large images before propagating them through the network. The inference step in the next cell will still take some time to execute."
+    "We can execute these steps manually and confirm that the result looks correct. To speed up inference time, resize large images before propagating them through the network. The inference step in the next cell will still take some time to execute. If you want to skip this step, set `PADDLEGAN_INFERENCE = False` in the first line of the next cell."
    ]
   },
   {
@@ -200,6 +200,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "PADDLEGAN_INFERENCE = True\n",
+    "\n",
     "# Step 1. Load the image and convert to RGB\n",
     "image_path = Path(\"coco_bricks.png\")\n",
     "\n",
@@ -212,26 +214,27 @@
     "transformed_image = predictor.transform(image)\n",
     "input_tensor = paddle.to_tensor(transformed_image[None, ::])\n",
     "\n",
-    "# Step 3. Do inference. \n",
-    "predictor.generator.eval()\n",
-    "with paddle.no_grad():\n",
-    "    result = predictor.generator(input_tensor)\n",
+    "if PADDLEGAN_INFERENCE:\n",
+    "    # Step 3. Do inference. \n",
+    "    predictor.generator.eval()\n",
+    "    with paddle.no_grad():\n",
+    "        result = predictor.generator(input_tensor)\n",
     "\n",
-    "# Step 4. Convert the inference result to an image following the same steps as\n",
-    "# PaddleGAN's predictor.run() function\n",
-    "result_image_pg = (result * 0.5 + 0.5)[0].numpy() * 255\n",
-    "result_image_pg = result_image_pg.transpose((1, 2, 0))\n",
+    "    # Step 4. Convert the inference result to an image following the same steps as\n",
+    "    # PaddleGAN's predictor.run() function\n",
+    "    result_image_pg = (result * 0.5 + 0.5)[0].numpy() * 255\n",
+    "    result_image_pg = result_image_pg.transpose((1, 2, 0))\n",
     "\n",
-    "# Step 5. Resize the result image\n",
-    "result_image_pg = cv2.resize(result_image_pg, image.shape[:2][::-1])\n",
+    "    # Step 5. Resize the result image\n",
+    "    result_image_pg = cv2.resize(result_image_pg, image.shape[:2][::-1])\n",
     "\n",
-    "# Step 6. Adjust the brightness\n",
-    "result_image_pg = predictor.adjust_brightness(result_image_pg, image)\n",
+    "    # Step 6. Adjust the brightness\n",
+    "    result_image_pg = predictor.adjust_brightness(result_image_pg, image)\n",
     "\n",
-    "# Step 7. Save the result image\n",
-    "anime_image_path_pg = image_path.with_name(image_path.stem + \"_anime_pg\").with_suffix(\".jpg\")\n",
-    "if cv2.imwrite(str(anime_image_path_pg), result_image_pg[:, :, (2, 1, 0)]):\n",
-    "    print(f\"The anime image was saved to {anime_image_path_pg}\")"
+    "    # Step 7. Save the result image\n",
+    "    anime_image_path_pg = image_path.with_name(image_path.stem + \"_anime_pg\").with_suffix(\".jpg\")\n",
+    "    if cv2.imwrite(str(anime_image_path_pg), result_image_pg[:, :, (2, 1, 0)]):\n",
+    "        print(f\"The anime image was saved to {anime_image_path_pg}\")"
    ]
   },
   {
@@ -249,9 +252,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(1, 2, figsize=(25, 15))\n",
-    "ax[0].imshow(image)\n",
-    "ax[1].imshow(result_image_pg)"
+    "if PADDLEGAN_INFERENCE:\n",
+    "    fig, ax = plt.subplots(1, 2, figsize=(25, 15))\n",
+    "    ax[0].imshow(image)\n",
+    "    ax[1].imshow(result_image_pg)\n",
+    "else:\n",
+    "    print(\"PADDLEGAN_INFERENCE is not enabled. Set PADDLEGAN_INFERENCE = True in the previous cell and run that cell to show inference results.\")"
    ]
   },
   {
@@ -350,7 +356,7 @@
     "the minimum size to resize to. The ResizeToScale transform resizes images to the size specified in the\n",
     "ResizeToScale params, with width and height as multiples of 32.\n",
     "\n",
-    "Now that we know the mean and standard deviation values, and the shape of the model inputs, we can call Model Optimizer and convert the model to IR with these values. "
+    "Now that we know the mean and standard deviation values, and the shape of the model inputs, we can call Model Optimizer and convert the model to IR with these values. We use FP16 precision and set log level to CRITICAL to ignore warnings that are irrelevant for this demo. See the [Model Optimizer Documentation](https://docs.openvinotoolkit.org/latest/openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model_General.html) for information about Model Optimizer parameters."
    ]
   },
   {
@@ -372,7 +378,7 @@
     "python = sys.executable\n",
     "onnx_path = model_path.with_suffix(\".onnx\")\n",
     "print(\"Exporting ONNX model to IR... This may take a few minutes.\")\n",
-    "! $python $mo --input_model $onnx_path --input_shape [1,3,$target_height,$target_width] --model_name $MODEL_NAME --data_type \"FP16\" --mean_values=\"[127.5,127.5,127.5]\" --scale_values=\"[127.5,127.5,127.5]\""
+    "! $python $mo --input_model $onnx_path --input_shape [1,3,$target_height,$target_width] --model_name $MODEL_NAME --data_type \"FP16\" --mean_values=\"[127.5,127.5,127.5]\" --scale_values=\"[127.5,127.5,127.5]\" --log_level \"CRITICAL\""
    ]
   },
   {
@@ -590,17 +596,23 @@
     "# else:\n",
     "#     print(\"A supported iGPU device is not available on this system.\")\n",
     "\n",
+    "## PADDLEGAN_INFERENCE is defined in the section \"Inference on PaddleGAN model\"\n",
+    "## Uncomment the next line to enable a performance comparison with the PaddleGAN model \n",
+    "## if you disabled it earlier. \n",
     "\n",
-    "with paddle.no_grad():\n",
-    "    start = time.perf_counter()\n",
-    "    for _ in range(NUM_IMAGES):\n",
-    "        predictor.generator(input_tensor)\n",
-    "    end = time.perf_counter()\n",
-    "    time_paddle = end - start\n",
-    "print(\n",
-    "    f\"PaddleGAN model on CPU: {time_paddle/NUM_IMAGES:.3f} seconds per image, \"\n",
-    "    f\"FPS: {NUM_IMAGES/time_paddle:.2f}\"\n",
-    ")"
+    "# PADDLEGAN_INFERENCE = True\n",
+    "\n",
+    "if PADDLEGAN_INFERENCE:\n",
+    "    with paddle.no_grad():\n",
+    "        start = time.perf_counter()\n",
+    "        for _ in range(NUM_IMAGES):\n",
+    "            predictor.generator(input_tensor)\n",
+    "        end = time.perf_counter()\n",
+    "        time_paddle = end - start\n",
+    "    print(\n",
+    "        f\"PaddleGAN model on CPU: {time_paddle/NUM_IMAGES:.3f} seconds per image, \"\n",
+    "        f\"FPS: {NUM_IMAGES/time_paddle:.2f}\"\n",
+    "    )"
    ]
   },
   {


### PR DESCRIPTION
Add PADDLEGAN_INFERENCE setting. Default True, if set to False, inference on PaddlePaddle model will be skipped. This allows running the notebook on systems with limited resources, and speeds up "Run All Cells" if you are not interested in comparisons with the original PaddleGAN model but just want to quickly show the notebook.

This allows the notebook to run on Binder too.

Also added `--log_level = CRITICAL` to MO to prevent showing some errors that are not relevant for this demo.