### PR TITLE
Replace Tensorflow with TensorFlow

### DIFF
--- a/.docker/requirements.in
+++ b/.docker/requirements.in
@@ -21,7 +21,7 @@ ipywidgets
 torch>=1.5.1+cpu,<=1.7.1+cpu
 torchvision>=0.6.1+cpu,<=0.8.2+cpu
 
-# Tensorflow notebook requirements
+# TensorFlow notebook requirements
 networkx>=1.11
 defusedxml>=0.5.0
 tensorflow==2.4.2

--- a/notebooks/001-hello-world/001-hello-world.ipynb
+++ b/notebooks/001-hello-world/001-hello-world.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "A very basic introduction to OpenVINO that shows how to do inference on a given IR model.\n",
     "\n",
-    "We use a [MobileNetV3 model](https://docs.openvinotoolkit.org/latest/omz_models_model_mobilenet_v3_small_1_0_224_tf.html) from [Open Model Zoo](https://github.com/openvinotoolkit/open_model_zoo/). See the [Tensorflow to OpenVINO Notebook](101-tensorflow-to-openvino) for information on how this OpenVINO IR model was created.\n",
+    "We use a [MobileNetV3 model](https://docs.openvinotoolkit.org/latest/omz_models_model_mobilenet_v3_small_1_0_224_tf.html) from [Open Model Zoo](https://github.com/openvinotoolkit/open_model_zoo/). See the [TensorFlow to OpenVINO Notebook](101-tensorflow-to-openvino) for information on how this OpenVINO IR model was created.\n",
     "\n"
    ]
   },

--- a/notebooks/002-openvino-api/002-openvino-api.ipynb
+++ b/notebooks/002-openvino-api/002-openvino-api.ipynb
@@ -88,7 +88,7 @@
     "\n",
     "An IR (Intermediate Representation) model consists of an .xml file, containing model information, and a .bin file, containing the weights. `read_network()` expects the weights file to be located in the same directory as the xml file, with the same filename, and the extension .bin: `model_weights_file == Path(model_xml).with_suffix(\".bin\")`. If this is the case, specifying the weights file is optional. If the weights file has a different filename, it can be specified with the `weights` parameter to `read_network()`.\n",
     "\n",
-    "See the [tensorflow-to-openvino](../101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb) and [pytorch-onnx-to-openvino](../102-pytorch-onnx-to-openvino/102-pytorch-onnx-to-openvino.ipynb) notebooks for information on how to convert your existing Tensorflow, PyTorch or ONNX model to OpenVINO's IR format."
+    "See the [tensorflow-to-openvino](../101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb) and [pytorch-onnx-to-openvino](../102-pytorch-onnx-to-openvino/102-pytorch-onnx-to-openvino.ipynb) notebooks for information on how to convert your existing TensorFlow, PyTorch or ONNX model to OpenVINO's IR format."
    ]
   },
   {

--- a/notebooks/101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb
+++ b/notebooks/101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb
@@ -6,7 +6,7 @@
     "id": "JwEAhQVzkAwA"
    },
    "source": [
-    "# Tensorflow to OpenVINO\n",
+    "# TensorFlow to OpenVINO\n",
     "\n",
     "This short tutorial shows how to convert a TensorFlow MobilenetV3 model to OpenVINO IR format.\n",
     "Model documentation: https://docs.openvinotoolkit.org/latest/omz_models_model_mobilenet_v3_small_1_0_224_tf.html"

--- a/notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino.ipynb
+++ b/notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino.ipynb
@@ -27,11 +27,11 @@
     "id": "KwQtSOz0VrVX"
    },
    "source": [
-    "## From Training to Deployment with Tensorflow and OpenVINO \n",
+    "## From Training to Deployment with TensorFlow and OpenVINO \n",
     "\n",
-    "This example demonstrates how to train, convert, and deploy an image classification model with Tensorflow and OpenVINO. This particular notebook shows the process where we perform the inference step on the freshly trained model. \n",
+    "This example demonstrates how to train, convert, and deploy an image classification model with TensorFlow and OpenVINO. This particular notebook shows the process where we perform the inference step on the freshly trained model. \n",
     "\n",
-    "The training code is based on the official Tensorflow Image Classification Tutorial: (https://www.tensorflow.org/tutorials/images/classification).\n",
+    "The training code is based on the official TensorFlow Image Classification Tutorial: (https://www.tensorflow.org/tutorials/images/classification).\n",
     "\n",
     "The **flower_ir.bin** and **flower_ir.xml** (pre-trained models) can be obtained by executing the code with 'Runtime->Run All' or the Ctrl+F9 command. \n"
    ]
@@ -40,7 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Tensorflow Image Classification Training"
+    "## TensorFlow Image Classification Training"
    ]
   },
   {
@@ -49,7 +49,7 @@
     "id": "gN7G9GFmVrVY"
    },
    "source": [
-    "The first part of the tutorial shows how to classify images of flowers (based on the Tensorflow's official tutorial). It creates an image classifier using a `keras.Sequential` model, and loads data using `preprocessing.image_dataset_from_directory`. You will gain practical experience with the following concepts:\n",
+    "The first part of the tutorial shows how to classify images of flowers (based on the TensorFlow's official tutorial). It creates an image classifier using a `keras.Sequential` model, and loads data using `preprocessing.image_dataset_from_directory`. You will gain practical experience with the following concepts:\n",
     "\n",
     "* Efficiently loading a dataset off disk.\n",
     "* Identifying overfitting and applying techniques to mitigate it, including data augmentation and Dropout.\n",
@@ -959,7 +959,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Save the Tensorflow Model"
+    "## Save the TensorFlow Model"
    ]
   },
   {


### PR DESCRIPTION
The official spelling/capitalization is TensorFlow - we did not have this everywhere. I changed all Tensorflow occurrences to TensorFlow