### PR TITLE
Add note about C++ to installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ The notebooks run almost anywhere &mdash; your laptop, a cloud VM, or even a Doc
 
 ## 📝 Installation Guide
 
-OpenVINO Notebooks require Python and Git. See instructions below for your operating system:
+OpenVINO Notebooks require Python and Git. For Python 3.8, C++ is also required. See instructions below for your operating system:
 
 | [Windows 10](https://github.com/openvinotoolkit/openvino_notebooks/wiki/Windows) | [Ubuntu](https://github.com/openvinotoolkit/openvino_notebooks/wiki/Ubuntu) | [macOS](https://github.com/openvinotoolkit/openvino_notebooks/wiki/macOS) | [Red Hat](https://github.com/openvinotoolkit/openvino_notebooks/wiki/Red-Hat-and-CentOS) | [CentOS](https://github.com/openvinotoolkit/openvino_notebooks/wiki/Red-Hat-and-CentOS) | [Azure ML](https://github.com/openvinotoolkit/openvino_notebooks/wiki/AzureML) |
 | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 
-Once you have installed Python and Git, follow the steps below.
+Once you have installed Python, Git and C++, follow the steps below.
 
 ### Step 1: Create and Activate `openvino_env` Environment
 


### PR DESCRIPTION
openvino-dev recently started requiring C++ because it is required by a dependency that is used for a few supported models. 
Add a note about this to the main README and an extra step in the Windows Guide https://github.com/openvinotoolkit/openvino_notebooks/wiki/Windows