### PR TITLE
Show device names in 104 notebook

### DIFF
--- a/notebooks/104-model-tools/104-model-tools.ipynb
+++ b/notebooks/104-model-tools/104-model-tools.ipynb
@@ -325,7 +325,7 @@
     "\n",
     "Run `! benchmark_app --help` to get an overview of all possible command line parameters.\n",
     "\n",
-    "In the next cell, we define a `benchmark_model()` function that calls `benchmark_app`. This makes it easy to try different combinations."
+    "In the next cell, we define a `benchmark_model()` function that calls `benchmark_app`. This makes it easy to try different combinations. In the cell below that, we display the available devices on the system."
    ]
   },
   {
@@ -348,6 +348,21 @@
     "        benchmark_output = %sx $benchmark_command\n",
     "        benchmark_result = [line for line in benchmark_output if not (line.startswith(r\"[\") or line.startswith(\"  \") or line==\"\")]\n",
     "        print(\"\\n\".join(benchmark_result))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "298904f0-638c-4958-876a-3b8c8bd06518",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ie = IECore()\n",
+    "\n",
+    "# Show devices available for OpenVINO Inference Engine\n",
+    "for device in ie.available_devices:\n",
+    "    device_name = ie.get_metric(device, \"FULL_DEVICE_NAME\")\n",
+    "    print(f\"{device}: {device_name}\")"
    ]
   },
   {


### PR DESCRIPTION
Adds a cell that shows device info above the benchmark_app commands. Performance information is not very useful without this information, and if you make a screenshot of the results, it is useful to be able to include this.
![image](https://user-images.githubusercontent.com/77325899/125639206-c4c1b8ff-9c71-461c-8ead-4e3685027490.png)
