### PR TITLE
104: support OMZ models with multiple model files

### DIFF
--- a/notebooks/104-model-tools/104-model-tools.ipynb
+++ b/notebooks/104-model-tools/104-model-tools.ipynb
@@ -240,7 +240,7 @@
     "model_info_output = %sx omz_info_dumper --name $model_name\n",
     "model_info = json.loads(model_info_output.get_nlstr())\n",
     "\n",
-    "if len(model_info) > 0:\n",
+    "if len(model_info) > 1:\n",
     "    NotebookAlert(\n",
     "        f\"There are multiple IR files for the {model_name} model. The first model in the \"\n",
     "        \"omz_info_dumper output will be used for benchmarking. Change \"\n",

--- a/notebooks/104-model-tools/104-model-tools.ipynb
+++ b/notebooks/104-model-tools/104-model-tools.ipynb
@@ -75,24 +75,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import json\n",
     "import os.path\n",
     "import subprocess\n",
     "import sys\n",
     "from pathlib import Path\n",
-    "from openvino.inference_engine import IECore\n",
-    "from IPython.display import Markdown\n",
-    "import json\n",
     "\n",
-    "# Import an error checking function and define a backup class if notebook_utils is not available\n",
+    "from IPython.display import Markdown\n",
+    "from openvino.inference_engine import IECore\n",
+    "\n",
     "sys.path.append(\"../utils\")\n",
-    "class SimpleGPUNotFoundAlert(object):\n",
-    "    def __init__(self):\n",
-    "        print(\"Running this cell requires an integrated GPU, which is not available on this system.\")\n",
-    "        \n",
-    "try:\n",
-    "    from notebook_utils import GPUNotFoundAlert\n",
-    "except:\n",
-    "    GPUNotFoundAlert = SimpleGPUNotFoundAlert"
+    "from notebook_utils import GPUNotFoundAlert, NotebookAlert"
    ]
   },
   {
@@ -130,7 +123,9 @@
     "ie = IECore()\n",
     "gpu_available = \"GPU\" in ie.available_devices\n",
     "\n",
-    "print(f\"base_model_dir: {base_model_dir}, omz_cache_dir: {omz_cache_dir}, gpu_availble: {gpu_available}\")"
+    "print(\n",
+    "    f\"base_model_dir: {base_model_dir}, omz_cache_dir: {omz_cache_dir}, gpu_availble: {gpu_available}\"\n",
+    ")"
    ]
   },
   {
@@ -169,7 +164,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "download_command = f\"omz_downloader --name {model_name} --output_dir {base_model_dir} --cache_dir {omz_cache_dir}\"\n",
+    "download_command = (\n",
+    "    f\"omz_downloader --name {model_name} --output_dir {base_model_dir} --cache_dir {omz_cache_dir}\"\n",
+    ")\n",
     "display(Markdown(f\"Download command: `{download_command}`\"))\n",
     "display(Markdown(f\"Downloading {model_name}...\"))\n",
     "! $download_command"
@@ -241,7 +238,16 @@
    "outputs": [],
    "source": [
     "model_info_output = %sx omz_info_dumper --name $model_name\n",
-    "model_info = json.loads(model_info_output.get_nlstr())[0]\n",
+    "model_info = json.loads(model_info_output.get_nlstr())\n",
+    "\n",
+    "if len(model_info) > 0:\n",
+    "    NotebookAlert(\n",
+    "        f\"There are multiple IR files for the {model_name} model. The first model in the \"\n",
+    "        \"omz_info_dumper output will be used for benchmarking. Change \"\n",
+    "        \"`selected_model_info` in the cell below to select a different model from the list.\",\n",
+    "        \"warning\",\n",
+    "    )\n",
+    "    \n",
     "model_info"
    ]
   },
@@ -260,7 +266,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_path = base_model_dir / Path(model_info[\"subdirectory\"]) / Path(f\"{precision}/{model_name}.xml\")\n",
+    "selected_model_info = model_info[0]\n",
+    "model_path = (\n",
+    "    base_model_dir\n",
+    "    / Path(selected_model_info[\"subdirectory\"])\n",
+    "    / Path(f\"{precision}/{selected_model_info['name']}.xml\")\n",
+    ")\n",
     "print(model_path, \"exists:\", model_path.exists())"
    ]
   },


### PR DESCRIPTION
Solves issue that benchmarking part did not work for models with multiple model files.  Now when there are multiple models, the first is chosen, and a warning message is displayed.
![image](https://user-images.githubusercontent.com/77325899/126557183-e8613d1f-f00e-482c-808b-33e0871b74c3.png)

Also formatted the code, and removed the backup function for the warning/alert class. I added that in the first version for if notebook_utils was not available, but it adds clutter and seems unnecessary. 