### PR TITLE
Fix docker test

### DIFF
--- a/.docker/.s2i/bin/test
+++ b/.docker/.s2i/bin/test
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -eo pipefail
-
+export HUB_HOME=/tmp
 
 # Pre-clone repositories defined in JUPYTER_PRELOAD_REPOS
 if [ -n "${JUPYTER_PRELOAD_REPOS}" ]; then


### PR DESCRIPTION
Add HUB_HOME to Docker test file. 
This fixes the Docker nbval test. The 103 notebook worked fine in the Docker image when run manually, but the test failed because the test script was missing this environment variable. Code duplication between run and test script should be fixed in future PR.