### PR TITLE
Make PyTube downloading more robust in 202

### DIFF
--- a/notebooks/202-vision-superresolution/202-vision-superresolution-video.ipynb
+++ b/notebooks/202-vision-superresolution/202-vision-superresolution-video.ipynb
@@ -2,6 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "74e3c567",
+   "metadata": {},
    "source": [
     "# Super Resolution with OpenVINO\n",
     "Super Resolution is the process of enhancing the quality of an image by increasing the pixel count using deep learning. This notebook applies Single Image Super Resolution (SISR) to frames in a 360p (480×360) video in 360p resolution. We use a model called [single-image-super-resolution-1032](https://github.com/openvinotoolkit/open_model_zoo/tree/develop/models/intel/single-image-super-resolution-1032) which is available from the Open Model Zoo. It is based on the research paper cited below. \n",
@@ -9,63 +11,61 @@
     "Y. Liu et al., [\"An Attention-Based Approach for Single Image Super Resolution,\"](https://arxiv.org/abs/1807.06779) 2018 24th International Conference on Pattern Recognition (ICPR), 2018, pp. 2777-2784, doi: 10.1109/ICPR.2018.8545760.\n",
     "\n",
     "**NOTE:** The Single Image Super Resolution (SISR) model used in this demo is not optimized for video. Results may vary depending on the video. We are looking for a more suitable Multi Image Super Resolution (MISR) model, so if you know of a great open source model, please let us know! You can start a [discussion](https://github.com/openvinotoolkit/openvino_notebooks/discussions) or create an [issue](https://github.com/openvinotoolkit/openvino_notebooks/issues) on GitHub. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "15b1575b",
+   "metadata": {},
    "source": [
     "## Preparation"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4026645b",
+   "metadata": {},
    "source": [
     "### Imports"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4ef55816",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "import os\n",
-    "import socket\n",
     "import time\n",
     "import urllib\n",
     "from pathlib import Path\n",
     "\n",
     "import cv2\n",
     "import numpy as np\n",
-    "import urllib\n",
-    "from IPython.display import (\n",
-    "    HTML,\n",
-    "    FileLink,\n",
-    "    Pretty,\n",
-    "    ProgressBar,\n",
-    "    Video,\n",
-    "    clear_output,\n",
-    "    display,\n",
-    ")\n",
+    "from IPython.display import HTML, FileLink, Pretty, ProgressBar, Video, clear_output, display\n",
     "from openvino.inference_engine import IECore\n",
     "from pytube import YouTube"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4891215e",
+   "metadata": {},
    "source": [
     "### Settings"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "582d9cde",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "# Device to use for inference. For example, \"CPU\", or \"GPU\"\n",
     "DEVICE = \"CPU\"\n",
@@ -73,22 +73,24 @@
     "MODEL_FILE = \"model/single-image-super-resolution-1032.xml\"\n",
     "model_name = os.path.basename(MODEL_FILE)\n",
     "model_xml_path = Path(MODEL_FILE).with_suffix(\".xml\")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cdd4c452",
+   "metadata": {},
    "source": [
     "### Functions\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4818ca56",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "def write_text_on_image(image: np.ndarray, text: str) -> np.ndarray:\n",
     "    \"\"\"\n",
@@ -109,12 +111,8 @@
     "    x, y = org\n",
     "\n",
     "    image = cv2.UMat(image)\n",
-    "    (text_w, text_h), _ = cv2.getTextSize(\n",
-    "        text, font, font_scale, font_thickness\n",
-    "    )\n",
-    "    result_im = cv2.rectangle(\n",
-    "        image, org, (x + text_w, y + text_h), text_color_bg, -1\n",
-    "    )\n",
+    "    (text_w, text_h), _ = cv2.getTextSize(text, font, font_scale, font_thickness)\n",
+    "    result_im = cv2.rectangle(image, org, (x + text_w, y + text_h), text_color_bg, -1)\n",
     "\n",
     "    textim = cv2.putText(\n",
     "        result_im,\n",
@@ -139,9 +137,7 @@
     "    if path.startswith(\"http\"):\n",
     "        # Set User-Agent to Mozilla because some websites block requests\n",
     "        # with User-Agent Python\n",
-    "        request = urllib.request.Request(\n",
-    "            path, headers={\"User-Agent\": \"Mozilla/5.0\"}\n",
-    "        )\n",
+    "        request = urllib.request.Request(path, headers={\"User-Agent\": \"Mozilla/5.0\"})\n",
     "        response = urllib.request.urlopen(request)\n",
     "        array = np.asarray(bytearray(response.read()), dtype=\"uint8\")\n",
     "        image = cv2.imdecode(array, -1)  # Loads the image as BGR\n",
@@ -163,51 +159,54 @@
     "    result[result > 255] = 255\n",
     "    result = result.astype(np.uint8)\n",
     "    return result"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "587c554b",
+   "metadata": {},
    "source": [
     "## Load the Superresolution Model"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8b8dc8ea",
+   "metadata": {},
    "source": [
     "Load the model in Inference Engine with `ie.read_network` and load it to the specified device with `ie.load_network`"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "ie = IECore()\n",
-    "net = ie.read_network(\n",
-    "    str(model_xml_path), str(model_xml_path.with_suffix(\".bin\"))\n",
-    ")\n",
-    "exec_net = ie.load_network(network=net, device_name=DEVICE)"
-   ],
-   "outputs": [],
+   "id": "c8fee7d4",
    "metadata": {
     "tags": []
-   }
+   },
+   "outputs": [],
+   "source": [
+    "ie = IECore()\n",
+    "net = ie.read_network(str(model_xml_path), str(model_xml_path.with_suffix(\".bin\")))\n",
+    "exec_net = ie.load_network(network=net, device_name=DEVICE)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d897ad82",
+   "metadata": {},
    "source": [
     "Get information about network inputs and outputs. The Super Resolution model expects two inputs: 1) the input image, 2) a bicubic interpolation of the input image to the target size 1920x1080. It returns the super resolution version of the image in 1920x1800. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b23a5d80",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "# Network inputs and outputs are dictionaries. Get the keys for the\n",
     "# dictionaries.\n",
@@ -218,37 +217,25 @@
     "# Get the expected input and target shape. `.dims[2:]` returns the height\n",
     "# and width. OpenCV's resize function expects the shape as (width, height),\n",
     "# so we reverse the shape with `[::-1]` and convert it to a tuple\n",
-    "input_height, input_width = tuple(\n",
-    "    exec_net.input_info[original_image_key].tensor_desc.dims[2:]\n",
-    ")\n",
-    "target_height, target_width = tuple(\n",
-    "    exec_net.input_info[bicubic_image_key].tensor_desc.dims[2:]\n",
-    ")\n",
+    "input_height, input_width = tuple(exec_net.input_info[original_image_key].tensor_desc.dims[2:])\n",
+    "target_height, target_width = tuple(exec_net.input_info[bicubic_image_key].tensor_desc.dims[2:])\n",
     "\n",
     "upsample_factor = int(target_height / input_height)\n",
     "\n",
-    "print(\n",
-    "    f\"The network expects inputs with a width of {input_width}, \"\n",
-    "    f\"height of {input_height}\"\n",
-    ")\n",
-    "print(\n",
-    "    f\"The network returns images with a width of {target_width}, \"\n",
-    "    f\"height of {target_height}\"\n",
-    ")\n",
+    "print(f\"The network expects inputs with a width of {input_width}, \" f\"height of {input_height}\")\n",
+    "print(f\"The network returns images with a width of {target_width}, \" f\"height of {target_height}\")\n",
     "\n",
     "print(\n",
     "    f\"The image sides are upsampled by a factor {upsample_factor}. \"\n",
     "    f\"The new image is {upsample_factor**2} times as large as the \"\n",
     "    \"original image\"\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "564fc343",
+   "metadata": {},
    "source": [
     "## Superresolution on Video\n",
     "\n",
@@ -259,19 +246,24 @@
     "**Note:**\n",
     "- The resulting video does not contain audio.\n",
     "- The input video should be a landscape video and have an an input resultion of 360p (640x360) for the 1032 model, or 480p (720x480) for the 1033 model."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b8356c7b",
+   "metadata": {},
    "source": [
     "### Settings"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "af99b289",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "VIDEO_DIR = \"data\"\n",
     "OUTPUT_DIR = \"output\"\n",
@@ -283,22 +275,24 @@
     "# vp09 is slow, but widely available. If you have FFMPEG installed, you can\n",
     "# change the FOURCC to `*\"THEO\"` to improve video writing speed\n",
     "FOURCC = cv2.VideoWriter_fourcc(*\"vp09\")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "84a630d4",
+   "metadata": {},
    "source": [
     "### Download and Prepare Video"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "76b55b9c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "# Use pytube to download a video. It downloads to the videos subdirectory.\n",
     "# You can also place a local video there and comment out the following lines\n",
@@ -310,31 +304,30 @@
     "try:\n",
     "    os.makedirs(VIDEO_DIR, exist_ok=True)\n",
     "    stream = yt.streams.filter(resolution=\"360p\").first()\n",
-    "    filename = Path(\n",
-    "        stream.default_filename.encode(\"ascii\", \"ignore\").decode(\"ascii\")\n",
-    "    ).stem\n",
+    "    filename = Path(stream.default_filename.encode(\"ascii\", \"ignore\").decode(\"ascii\")).stem\n",
     "    stream.download(OUTPUT_DIR, filename=filename)\n",
     "    print(f\"Video {filename} downloaded to {OUTPUT_DIR}\")\n",
     "\n",
     "    # Create Path objects for the input video and the resulting videos\n",
     "    video_path = Path(stream.get_file_path(filename, OUTPUT_DIR))\n",
-    "except (socket.timeout, TimeoutError, urllib.error.HTTPError):\n",
+    "except Exception:\n",
     "    # If PyTube fails, use a local video stored in the VIDEO_DIR directory\n",
     "    video_path = Path(rf\"{VIDEO_DIR}/CEO Pat Gelsinger on Leading Intel.mp4\")\n",
     "\n",
     "# Path names for the result videos\n",
     "superres_video_path = Path(f\"{OUTPUT_DIR}/{video_path.stem}_superres.mp4\")\n",
     "bicubic_video_path = Path(f\"{OUTPUT_DIR}/{video_path.stem}_bicubic.mp4\")\n",
-    "comparison_video_path = Path(f\"{OUTPUT_DIR}/{video_path.stem}_superres_comparison.mp4\")\n"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+    "comparison_video_path = Path(f\"{OUTPUT_DIR}/{video_path.stem}_superres_comparison.mp4\")"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "678b6cf5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "# Open the video and get the dimensions and the FPS\n",
     "cap = cv2.VideoCapture(str(video_path))\n",
@@ -349,22 +342,24 @@
     "    f\"The input video has a frame width of {original_frame_width}, \"\n",
     "    f\"frame height of {original_frame_height} and runs at {fps:.2f} fps\"\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "6fd26468",
+   "metadata": {},
    "source": [
     "Create superresolution video, bicubic video and comparison video. The superresolution video contains the enhanced video, upsampled with superresolution, the bicubic video is the input video upsampled with bicubic interpolation, the combination video sets the bicubic video and the superresolution side by side."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8b5aacc9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "superres_video = cv2.VideoWriter(\n",
     "    str(superres_video_path),\n",
@@ -384,33 +379,33 @@
     "    fps,\n",
     "    (target_width * 2, target_height),\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "27b5c979",
+   "metadata": {},
    "source": [
     "### Do Inference\n",
     "\n",
     "Read video frames and enhance them with superresolution. Save the superresolution video, the bicubic video and the comparison video to file.\n",
     "\n",
     "The code in this cell reads the video frame by frame. Each frame is resized and reshaped to network input shape and upsampled with bicubic interpolation to target shape. Both the original and the bicubic image are propagated through the network. The network result is a numpy array with floating point values, with a shape of (1,3,1920,1080). This array is converted to an 8-bit image with shape (1080,1920,3) and written to `superres_video`. The bicubic image is written to `bicubic_video` for comparison. Lastly, the bicubic and result frames are combined side by side and written to `comparison_video`. A progress bar shows the progress of the process. Inference time is measured, as well as total time to process each frame, which includes inference time as well as the time it takes to process and write the video."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "12ac8de5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "start_time = time.perf_counter()\n",
     "frame_nr = 1\n",
     "total_inference_duration = 0\n",
-    "total_frames = (\n",
-    "    cap.get(cv2.CAP_PROP_FRAME_COUNT) if NUM_FRAMES == 0 else NUM_FRAMES\n",
-    ")\n",
+    "total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT) if NUM_FRAMES == 0 else NUM_FRAMES\n",
     "\n",
     "progress_bar = ProgressBar(total=total_frames)\n",
     "progress_bar.display()\n",
@@ -430,18 +425,14 @@
     "        # Resize the input image to network shape and convert from (H,W,C) to\n",
     "        # (N,C,H,W)\n",
     "        resized_image = cv2.resize(image, (input_width, input_height))\n",
-    "        input_image_original = np.expand_dims(\n",
-    "            resized_image.transpose(2, 0, 1), axis=0\n",
-    "        )\n",
+    "        input_image_original = np.expand_dims(resized_image.transpose(2, 0, 1), axis=0)\n",
     "\n",
     "        # Resize and reshape the image to the target shape with bicubic\n",
     "        # interpolation\n",
     "        bicubic_image = cv2.resize(\n",
     "            image, (target_width, target_height), interpolation=cv2.INTER_CUBIC\n",
     "        )\n",
-    "        input_image_bicubic = np.expand_dims(\n",
-    "            bicubic_image.transpose(2, 0, 1), axis=0\n",
-    "        )\n",
+    "        input_image_bicubic = np.expand_dims(bicubic_image.transpose(2, 0, 1), axis=0)\n",
     "\n",
     "        # Do inference\n",
     "        inference_start_time = time.perf_counter()\n",
@@ -495,22 +486,24 @@
     "        f\"(including video processing): {frame_nr/duration:.2f}. \"\n",
     "        f\"Inference FPS: {frame_nr/total_inference_duration:.2f}.\"\n",
     "    )"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "61022f66",
+   "metadata": {},
    "source": [
     "### Show side-by-side video of bicubic and superresolution version"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b32ba25d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "if not comparison_video_path.exists():\n",
     "    raise ValueError(\"The comparison video does not exist.\")\n",
@@ -524,18 +517,7 @@
     "        )\n",
     "    )\n",
     "    display(Video(comparison_video_path, width=800, embed=True))"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "source": [],
-   "outputs": [],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
I saw this notebook fail recently on PyTube download. This PR fixes that.
Most of the changes here are metadata/formatting updates. The relevant change is changing `"except (socket.timeout, TimeoutError, urllib.error.HTTPError):",` to `except Exception:`. With this change, the local video file will always be used, not just with the error types that are listed now. Bare exceptions are not a great idea, but for this demo notebook, this is what we want: if PyTube fails for whatever reason, we want the demo to run with the local video.

PyTube currently returns a 404 for the video - this is a known issue and will be fixed: `https://github.com/pytube/pytube/issues/1060`. Since we do not pin PyTube it will automatically work again when this is fixed (for new users - existing users may need to do `pip install --upgrade pytube`. 