### PR TITLE
Change read_network to use only model.xml

### DIFF
--- a/notebooks/001-hello-world/001-hello-world.ipynb
+++ b/notebooks/001-hello-world/001-hello-world.ipynb
@@ -2,6 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "291dc37b",
+   "metadata": {},
    "source": [
     "# Hello World\n",
     "\n",
@@ -9,19 +11,22 @@
     "\n",
     "We use a [MobileNetV3 model](https://docs.openvinotoolkit.org/latest/omz_models_model_mobilenet_v3_small_1_0_224_tf.html) from [Open Model Zoo](https://github.com/openvinotoolkit/open_model_zoo/). See the [TensorFlow to OpenVINO Notebook](101-tensorflow-to-openvino) for information on how this OpenVINO IR model was created.\n",
     "\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e4c8cbe5",
+   "metadata": {},
    "source": [
     "## Imports"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "41ee9436",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import json\n",
     "\n",
@@ -29,87 +34,88 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "from openvino.inference_engine import IECore"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "55e49ae7",
+   "metadata": {},
    "source": [
     "## Load the network"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e3c4d6fc",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "ie = IECore()\n",
-    "net = ie.read_network(\n",
-    "    model=\"model/v3-small_224_1.0_float.xml\", weights=\"model/v3-small_224_1.0_float.bin\"\n",
-    ")\n",
+    "net = ie.read_network(model=\"model/v3-small_224_1.0_float.xml\")\n",
     "exec_net = ie.load_network(net, \"CPU\")\n",
     "\n",
-    "input_key = list(exec_net.input_info)[0]\n",
-    "output_key = list(exec_net.outputs.keys())[0]"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "input_key = next(iter(exec_net.input_info))\n",
+    "output_key = next(iter(exec_net.outputs.keys()))"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "a19fc080",
+   "metadata": {},
    "source": [
     "## Load an Image"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "eca45b68",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# The MobileNet network expects images in RGB format\n",
     "image = cv2.cvtColor(cv2.imread(\"data/coco.jpg\"), cv2.COLOR_BGR2RGB)\n",
-    "input_image = cv2.resize(image, (224, 224))  # resize to MobileNet image shape\n",
-    "input_image = np.expand_dims(\n",
-    "    input_image.transpose(2, 0, 1), 0\n",
-    ")  # reshape to network input shape\n",
-    "plt.imshow(image)"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "# resize to MobileNet image shape\n",
+    "input_image = cv2.resize(image, (224, 224))\n",
+    "# reshape to network input shape\n",
+    "input_image = np.expand_dims(input_image.transpose(2, 0, 1), 0)\n",
+    "plt.imshow(image);"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "6be327b6",
+   "metadata": {},
    "source": [
     "## Do Inference"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1ed78a71",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "result = exec_net.infer(inputs={input_key: input_image})[output_key]\n",
     "result_index = np.argmax(result)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "bf29578c",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Convert the inference result to a class name.\n",
     "imagenet_classes = json.loads(open(\"utils/imagenet_class_index.json\").read())\n",
     "# The model description states that for this model, class 0 is background,\n",
     "# so we add 1 to the network output to get the class name\n",
-    "imagenet_classes = {\n",
-    "    int(key) + 1: value for key, value in imagenet_classes.items()\n",
-    "}\n",
+    "imagenet_classes = {int(key) + 1: value for key, value in imagenet_classes.items()}\n",
     "imagenet_classes[result_index]"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb
+++ b/notebooks/101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb
@@ -2,28 +2,32 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "JwEAhQVzkAwA"
+   },
    "source": [
     "# TensorFlow to OpenVINO\n",
     "\n",
     "This short tutorial shows how to convert a TensorFlow MobilenetV3 model to OpenVINO IR format.\n",
     "Model documentation: https://docs.openvinotoolkit.org/latest/omz_models_model_mobilenet_v3_small_1_0_224_tf.html"
-   ],
-   "metadata": {
-    "id": "JwEAhQVzkAwA"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Imports"
-   ],
    "metadata": {
     "id": "QB4Yo-rGGLmV"
-   }
+   },
+   "source": [
+    "### Imports"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "2ynWRum4iiTz"
+   },
+   "outputs": [],
    "source": [
     "import json\n",
     "import sys\n",
@@ -35,32 +39,31 @@
     "import mo_tf\n",
     "import numpy as np\n",
     "from openvino.inference_engine import IECore"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "2ynWRum4iiTz"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Settings"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# The paths of the source and converted models\n",
     "model_path = Path(\"model/v3-small_224_1.0_float.pb\")\n",
     "ir_path = Path(model_path).with_suffix(\".xml\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "6JSoEIk60uxV"
+   },
    "source": [
     "## Convert the Model to OpenVINO IR Format\n",
     "\n",
@@ -70,14 +73,15 @@
     "\n",
     "We first construct the command for Model Optimizer, and then execute this command in the notebook by prepending the command with a `!`. There may be some errors or warnings in the output. Model Optimization was succesful if the last lines of the output include `[ SUCCESS ] Generated IR version 10 model.\n",
     "`"
-   ],
-   "metadata": {
-    "id": "6JSoEIk60uxV"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "# Get the path to the Model Optimizer script\n",
     "mo_path = str(Path(mo_tf.__file__))\n",
@@ -95,15 +99,13 @@
     "mo_command = \" \".join(mo_command.split())\n",
     "print(\"Model Optimizer command to convert TensorFlow to OpenVINO:\")\n",
     "print(mo_command)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Run Model Optimizer if the IR model file does not exist\n",
     "if not ir_path.exists():\n",
@@ -111,65 +113,65 @@
     "    ! $mo_command\n",
     "else:\n",
     "    print(f\"IR model {ir_path} already exists.\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Test Inference on the Converted Model"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Load the model"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "ie = IECore()\n",
-    "net = ie.read_network(str(ir_path), str(ir_path.with_suffix(\".bin\")))\n",
+    "net = ie.read_network(str(ir_path))\n",
     "exec_net = ie.load_network(net, \"CPU\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Get model information"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "input_key = list(exec_net.input_info)[0]\n",
     "output_key = list(exec_net.outputs.keys())[0]\n",
     "network_input_shape = exec_net.input_info[input_key].tensor_desc.dims"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Load image\n",
     "\n",
     "Load an image, resize it, and convert it to network input shape"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "image = cv2.cvtColor(cv2.imread(\"data/coco.jpg\"), cv2.COLOR_BGR2RGB)\n",
     "# Resize image to network input image shape\n",
@@ -178,52 +180,52 @@
     "input_image = np.reshape(resized_image, network_input_shape) / 255\n",
     "input_image = np.expand_dims(np.transpose(resized_image, (2, 0, 1)), 0)\n",
     "plt.imshow(image)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Do inference"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "result = exec_net.infer(inputs={input_key: input_image})[output_key]\n",
     "result_index = np.argmax(result)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "imagenet_classes = json.loads(open(\"utils/imagenet_class_index.json\").read())\n",
     "imagenet_classes = {\n",
     "    int(key) + 1: value for key, value in imagenet_classes.items()\n",
     "}\n",
     "imagenet_classes[result_index]"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Timing\n",
     "\n",
     "Measure the time it takes to do inference on thousand images. This gives an indication of performance. For more accurate benchmarking, use the [OpenVINO benchmark tool](https://github.com/openvinotoolkit/openvino/tree/master/inference-engine/tools/benchmark_tool). Note that many optimizations are possible to improve the performance. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "num_images = 1000\n",
     "start = time.perf_counter()\n",
@@ -235,16 +237,14 @@
     "    f\"IR model in Inference Engine/CPU: {time_ir/num_images:.4f} \"\n",
     "    f\"seconds per image, FPS: {num_images/time_ir:.2f}\"\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/202-vision-superresolution/202-vision-superresolution-image.ipynb
+++ b/notebooks/202-vision-superresolution/202-vision-superresolution-image.ipynb
@@ -2,37 +2,46 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "7ab3e1c1",
+   "metadata": {},
    "source": [
     "# Super Resolution with OpenVINO"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "2a261517",
+   "metadata": {},
    "source": [
     "Super Resolution is the process of enhancing the quality of an image by increasing the pixel count using deep learning. This notebook shows the Single Image Super Resolution (SISR) which takes just one low resolution image. We use a model called [single-image-super-resolution-1032](https://github.com/openvinotoolkit/open_model_zoo/tree/develop/models/intel/single-image-super-resolution-1032) which is available from the Open Model Zoo. It is based on the research paper cited below. \n",
     "\n",
     "Y. Liu et al., [\"An Attention-Based Approach for Single Image Super Resolution,\"](https://arxiv.org/abs/1807.06779) 2018 24th International Conference on Pattern Recognition (ICPR), 2018, pp. 2777-2784, doi: 10.1109/ICPR.2018.8545760."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "c00428fe",
+   "metadata": {},
    "source": [
     "## Preparation"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ac2e7027",
+   "metadata": {},
    "source": [
     "### Imports"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9d4b04ac",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "import os\n",
     "import time\n",
@@ -47,22 +56,24 @@
     "from IPython.display import Pretty, ProgressBar, clear_output, display\n",
     "from openvino.inference_engine import IECore\n",
     "from PIL import Image"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "fb55a28c",
+   "metadata": {},
    "source": [
     "### Settings"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "322df115",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "# Device to use for inference. For example, \"CPU\", or \"GPU\"\n",
     "DEVICE = \"CPU\"\n",
@@ -70,22 +81,24 @@
     "MODEL_FILE = \"model/single-image-super-resolution-1032.xml\"\n",
     "model_name = os.path.basename(MODEL_FILE)\n",
     "model_xml_path = Path(MODEL_FILE).with_suffix(\".xml\")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ac90276e",
+   "metadata": {},
    "source": [
     "### Functions\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dd1426c7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "def write_text_on_image(image: np.ndarray, text: str) -> np.ndarray:\n",
     "    \"\"\"\n",
@@ -167,60 +180,64 @@
     "    Convert image_data from BGR to RGB\n",
     "    \"\"\"\n",
     "    return cv2.cvtColor(image_data, cv2.COLOR_BGR2RGB)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "944a341f",
+   "metadata": {},
    "source": [
     "## Load the superresolution model"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "53821181",
+   "metadata": {},
    "source": [
     "Load the model in Inference Engine with `ie.read_network` and load it to the specified device with `ie.load_network`\n",
     "\n",
     "The Super Resolution model expects two inputs: 1) the input image, 2) a bicubic interpolation of the input image to a size of 1920x1080. It returns the super resolution version of the image in 1920x1800 (for the default superresolution model (1032)). "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "57f76cfb",
+   "metadata": {},
    "source": [
     "Load the model in Inference Engine with `ie.read_network` and load it to the specified device with `ie.load_network`"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "ie = IECore()\n",
-    "net = ie.read_network(\n",
-    "    str(model_xml_path), str(model_xml_path.with_suffix(\".bin\"))\n",
-    ")\n",
-    "exec_net = ie.load_network(network=net, device_name=DEVICE)"
-   ],
-   "outputs": [],
+   "id": "96866b70",
    "metadata": {
     "tags": []
-   }
+   },
+   "outputs": [],
+   "source": [
+    "ie = IECore()\n",
+    "net = ie.read_network(str(model_xml_path))\n",
+    "exec_net = ie.load_network(network=net, device_name=DEVICE)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "9c836fa2",
+   "metadata": {},
    "source": [
     "Get information about network inputs and outputs. The Super Resolution model expects two inputs: 1) the input image, 2) a bicubic interpolation of the input image to the target size 1920x1080. It returns the super resolution version of the image in 1920x1800. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f84b9e15",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "# Network inputs and outputs are dictionaries. Get the keys for the\n",
     "# dictionaries.\n",
@@ -254,29 +271,32 @@
     "    f\"The new image is {upsample_factor**2} times as large as the \"\n",
     "    \"original image\"\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "2aa08460",
+   "metadata": {},
    "source": [
     "## Load and show the input image"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "7ae46441",
+   "metadata": {},
    "source": [
     "**NOTE:** For best results, use raw images (like TIFF, BMP or PNG). Compressed images (like JPEG) may appear distorted after processing with the super resolution model. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6cbbbd13",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "IMAGE_PATH = Path(\"data/tower.jpg\")\n",
     "OUTPUT_PATH = Path(\"output/\")\n",
@@ -294,31 +314,34 @@
     "    f\"Showing full image with width {full_image.shape[1]} \"\n",
     "    f\"and height {full_image.shape[0]}\"\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1eecb128",
+   "metadata": {},
    "source": [
     "## Superresolution on one crop of the image"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "fc5d16dd",
+   "metadata": {},
    "source": [
     "### Take one crop of the input image\n",
     "\n",
     "Take a crop of network input size. Give the X (width) and Y (height) coordinates for the top left corner of the crop. Set the CROP_FACTOR variable to 2 to make a crop that is larger than the network input size (this only works with the 1032 superresolution model). The crop will be downsampled before propagating to the network. This is useful for very high resolution images, where a crop of network input size is too small to show enough information. It can also improve the result. Note though that with a CROP_FACTOR or 2 the net upsampling factor will be halved. If the superresolution network increases the side lengths of the image by a factor four, it upsamples a 480x270 crop to 1920x1080. With a CROP_FACTOR of two, a 960x540 crop is upsampled to the same 1920x1080: the side lengths are twice as large as the crop size."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f86ec4d4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "# Set CROP_FACTOR to 2 to take crops with twice the input width and height\n",
     "# This only works with the 1032 (4x) superresolution model!\n",
@@ -342,24 +365,26 @@
     "    f\"height {image_crop.shape[0]}.\"\n",
     ")\n",
     "plt.imshow(to_rgb(image_crop));"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d5d8917b",
+   "metadata": {},
    "source": [
     "### Reshape/resize crop for network input\n",
     "\n",
     "The input image is resized to network input size, and reshaped to (N,C,H,W) (H=height, W=width, C=number of channels, N=number of images). The image is also resized to network output size, with bicubic interpolation. This bicubic image is the second input to the network."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dd2968e8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "# Resize the image to the target shape with bicubic interpolation\n",
     "bicubic_image = cv2.resize(\n",
@@ -373,24 +398,26 @@
     "# Reshape the images from (H,W,C) to (N,C,H,W)\n",
     "input_image_original = np.expand_dims(image_crop.transpose(2, 0, 1), axis=0)\n",
     "input_image_bicubic = np.expand_dims(bicubic_image.transpose(2, 0, 1), axis=0)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d2e217a6",
+   "metadata": {},
    "source": [
     "### Do inference\n",
     "\n",
     "Do inference and convert the inference result to an RGB image"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7b649dd4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "network_result = exec_net.infer(\n",
     "    inputs={\n",
@@ -400,48 +427,52 @@
     ")\n",
     "# Get inference result as numpy array and reshape to image shape and data type\n",
     "result_image = convert_result_to_image(network_result[output_key])"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d16b4928",
+   "metadata": {},
    "source": [
     "### Show and save results\n",
     "\n",
     "Show the bicubic image and the enhanced superresolution image."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3349cbc2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 2, figsize=(30, 15))\n",
     "ax[0].imshow(to_rgb(bicubic_image))\n",
     "ax[1].imshow(to_rgb(result_image))\n",
     "ax[0].set_title(\"Bicubic\")\n",
     "ax[1].set_title(\"Superresolution\")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "#### Save superresolution and bicubic image crop"
-   ],
+   "id": "2a643428",
    "metadata": {
     "tags": []
-   }
+   },
+   "source": [
+    "#### Save superresolution and bicubic image crop"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d7efcad7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "# Add text with \"SUPER\" or \"BICUBIC\" to the superresolution or bicubic image\n",
     "image_super = write_text_on_image(result_image, \"SUPER\")\n",
@@ -459,22 +490,24 @@
     "    str(bicubic_image_path), image_bicubic, [cv2.IMWRITE_PNG_COMPRESSION, 0]\n",
     ")\n",
     "print(f\"Images written to directory: {OUTPUT_PATH}\")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d217c577",
+   "metadata": {},
    "source": [
     "#### Write animated gif with bicubic/superresolution comparison"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a2f19391",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "result_pil = Image.fromarray(to_rgb(image_super))\n",
     "bicubic_pil = Image.fromarray(to_rgb(image_bicubic))\n",
@@ -491,24 +524,26 @@
     "\n",
     "# DisplayImage(str(gif_image_path)) doesn't work in Colab\n",
     "DisplayImage(open(gif_image_path, \"rb\").read(), width=1920 // 2)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b3e41243",
+   "metadata": {},
    "source": [
     "#### Create video with sliding bicubic/superresolution comparison\n",
     "\n",
     "This may take a while. For the video, the superresolution and bicubic image are resized by a factor two to improve processing speed. This gives an indication of the superresolution effect. The video is saved as an .avi video. You can click on the link to download the video, or open it directly from the images directory, and play it locally."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3b3b1db5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "FOURCC = cv2.VideoWriter_fourcc(*\"MJPG\")\n",
     "\n",
@@ -557,33 +592,36 @@
     "video_link = FileLink(result_video_path)\n",
     "video_link.html_link_str = \"<a href='%s' download>%s</a>\"\n",
     "display(HTML(f\"The video has been saved to {video_link._repr_html_()}\"))"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "12d53209",
+   "metadata": {},
    "source": [
     "## Superresolution on full input image\n",
     "\n",
     "Superresolution on the full image is done by dividing the image into patches of equal size, doing superresolution on each path, and then stitching the resulting patches together again. For this demo, patches near the border of the image are ignored.\n",
     "\n",
     "Adjust the `CROPLINES` setting in the next cell if you see boundary effects"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ad91374e",
+   "metadata": {},
    "source": [
     "### Compute patches"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fc35dc09",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "# Set the number of lines to crop from the network result to prevent\n",
     "# boundary effects. Should be an integer >= 1.\n",
@@ -625,24 +663,26 @@
     "    f\"The output image will have a width of {new_width} \"\n",
     "    f\"and a height of {new_height}\"\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "0cabe8da",
+   "metadata": {},
    "source": [
     "### Do inference\n",
     "\n",
     "The code in this cell reads one patch of the image at a time. Each patch is reshaped to network input shape and upsampled with bicubic interpolation to target shape. Both the original and the bicubic image are propagated through the network. The network result is a numpy array with floating point values, with a shape of (1,3,1920,1080). This array is converted to an 8-bit image with shape (1080,1920,3) and written to `full_superresolution_image`. The bicubic image is written to `full_bicubic_image` for comparison. A progress bar shows the progress of the process. Inference time is measured, as well as total time to process each patch."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "84306b5f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "start_time = time.perf_counter()\n",
     "patch_nr = 0\n",
@@ -757,37 +797,40 @@
     "    f\"{num_patches/duration:.2f}.\\nInference patches per second: \"\n",
     "    f\"{num_patches/total_inference_duration:.2f} \"\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "61760bac",
+   "metadata": {},
    "source": [
     "### Save superresolution image and the bicubic image"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1c98569a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "full_superresolution_image_path = Path(f\"{OUTPUT_PATH.stem}/full_superres_{adjusted_upsample_factor}x.jpg\")\n",
     "full_bicubic_image_path = Path(f\"{OUTPUT_PATH.stem}/full_bicubic_{adjusted_upsample_factor}x.jpg\")\n",
     "\n",
     "cv2.imwrite(str(full_superresolution_image_path), full_superresolution_image)\n",
     "cv2.imwrite(str(full_bicubic_image_path), full_bicubic_image);"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a262e821",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "bicubic_link = FileLink(full_bicubic_image_path)\n",
     "image_link = FileLink(full_superresolution_image_path)\n",
@@ -800,11 +843,7 @@
     "        f\"<ul><li>{image_link._repr_html_()}<li>{bicubic_link._repr_html_()}\"\n",
     "    )\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": []
-   }
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino.ipynb
+++ b/notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino.ipynb
@@ -3,6 +3,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# @title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
     "# you may not use this file except in compliance with the License.\n",
@@ -17,12 +19,13 @@
     "# limitations under the License.\n",
     "\n",
     "# Copyright 2018 The TensorFlow Authors"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "KwQtSOz0VrVX"
+   },
    "source": [
     "## From Training to Deployment with TensorFlow and OpenVINO \n",
     "\n",
@@ -31,20 +34,20 @@
     "The training code is based on the official TensorFlow Image Classification Tutorial: (https://www.tensorflow.org/tutorials/images/classification).\n",
     "\n",
     "The **flower_ir.bin** and **flower_ir.xml** (pre-trained models) can be obtained by executing the code with 'Runtime->Run All' or the Ctrl+F9 command. \n"
-   ],
-   "metadata": {
-    "id": "KwQtSOz0VrVX"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## TensorFlow Image Classification Training"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "gN7G9GFmVrVY"
+   },
    "source": [
     "The first part of the tutorial shows how to classify images of flowers (based on the TensorFlow's official tutorial). It creates an image classifier using a `keras.Sequential` model, and loads data using `preprocessing.image_dataset_from_directory`. You will gain practical experience with the following concepts:\n",
     "\n",
@@ -58,23 +61,24 @@
     "3. Build the model\n",
     "4. Train the model\n",
     "5. Test the model"
-   ],
-   "metadata": {
-    "id": "gN7G9GFmVrVY"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Import TensorFlow and other libraries"
-   ],
    "metadata": {
     "id": "zF9uvbXNVrVY"
-   }
+   },
+   "source": [
+    "## Import TensorFlow and other libraries"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "L1WtoaOHVrVh"
+   },
+   "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -93,23 +97,22 @@
     "from tensorflow import keras\n",
     "from tensorflow.keras import layers\n",
     "from tensorflow.keras.models import Sequential"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "L1WtoaOHVrVh"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Download and explore the dataset"
-   ],
    "metadata": {
     "id": "UZZI6lNkVrVm"
-   }
+   },
+   "source": [
+    "## Download and explore the dataset"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "DPHx8-t-VrVo"
+   },
    "source": [
     "This tutorial uses a dataset of about 3,700 photos of flowers. The dataset contains 5 sub-directories, one per class:\n",
     "\n",
@@ -121,164 +124,165 @@
     "  sunflowers/\n",
     "  tulips/\n",
     "```"
-   ],
-   "metadata": {
-    "id": "DPHx8-t-VrVo"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "57CcilYSG0zv"
+   },
+   "outputs": [],
    "source": [
     "import pathlib\n",
     "dataset_url = \"https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz\"\n",
     "data_dir = tf.keras.utils.get_file('flower_photos', origin=dataset_url, untar=True)\n",
     "data_dir = pathlib.Path(data_dir)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "57CcilYSG0zv"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "After downloading, you should now have a copy of the dataset available. There are 3,670 total images:"
-   ],
    "metadata": {
     "id": "VpmywIlsVrVx"
-   }
+   },
+   "source": [
+    "After downloading, you should now have a copy of the dataset available. There are 3,670 total images:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "SbtTDYhOHZb6"
+   },
+   "outputs": [],
    "source": [
     "image_count = len(list(data_dir.glob('*/*.jpg')))\n",
     "print(image_count)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "SbtTDYhOHZb6"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Here are some roses:"
-   ],
    "metadata": {
     "id": "PVmwkOSdHZ5A"
-   }
+   },
+   "source": [
+    "Here are some roses:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "N1loMlbYHeiJ"
+   },
+   "outputs": [],
    "source": [
     "roses = list(data_dir.glob('roses/*'))\n",
     "PIL.Image.open(str(roses[0]))"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "N1loMlbYHeiJ"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "PIL.Image.open(str(roses[1]))"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "RQbZBOTLHiUP"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "PIL.Image.open(str(roses[1]))"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "And some tulips:"
-   ],
    "metadata": {
     "id": "DGEqiBbRHnyI"
-   }
+   },
+   "source": [
+    "And some tulips:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "HyQkfPGdHilw"
+   },
+   "outputs": [],
    "source": [
     "tulips = list(data_dir.glob('tulips/*'))\n",
     "PIL.Image.open(str(tulips[0]))"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "HyQkfPGdHilw"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "PIL.Image.open(str(tulips[1]))"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "wtlhWJPAHivf"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "PIL.Image.open(str(tulips[1]))"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "gIjgz7_JIo_m"
+   },
    "source": [
     "# Load using keras.preprocessing\n",
     "\n",
     "Let's load these images off disk using the helpful [image_dataset_from_directory](https://www.tensorflow.org/api_docs/python/tf/keras/preprocessing/image_dataset_from_directory) utility. This will take you from a directory of images on disk to a `tf.data.Dataset` in just a couple lines of code. If you like, you can also write your own data loading code from scratch by visiting the [load images](https://www.tensorflow.org/tutorials/load_data/images) tutorial."
-   ],
-   "metadata": {
-    "id": "gIjgz7_JIo_m"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Create a dataset"
-   ],
    "metadata": {
     "id": "xyDNn9MbIzfT"
-   }
+   },
+   "source": [
+    "## Create a dataset"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Define some parameters for the loader:"
-   ],
    "metadata": {
     "id": "anqiK_AGI086"
-   }
+   },
+   "source": [
+    "Define some parameters for the loader:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "H74l2DoDI2XD"
+   },
+   "outputs": [],
    "source": [
     "batch_size = 32\n",
     "img_height = 180\n",
     "img_width = 180"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "H74l2DoDI2XD"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "It's good practice to use a validation split when developing your model. Let's use 80% of the images for training, and 20% for validation."
-   ],
    "metadata": {
     "id": "pFBhRrrEI49z"
-   }
+   },
+   "source": [
+    "It's good practice to use a validation split when developing your model. Let's use 80% of the images for training, and 20% for validation."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "fIR0kRZiI_AT"
+   },
+   "outputs": [],
    "source": [
     "train_ds = tf.keras.preprocessing.image_dataset_from_directory(\n",
     "  data_dir,\n",
@@ -287,15 +291,15 @@
     "  seed=123,\n",
     "  image_size=(img_height, img_width),\n",
     "  batch_size=batch_size)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "fIR0kRZiI_AT"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "iscU3UoVJBXj"
+   },
+   "outputs": [],
    "source": [
     "val_ds = tf.keras.preprocessing.image_dataset_from_directory(\n",
     "  data_dir,\n",
@@ -304,47 +308,47 @@
     "  seed=123,\n",
     "  image_size=(img_height, img_width),\n",
     "  batch_size=batch_size)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "iscU3UoVJBXj"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "You can find the class names in the `class_names` attribute on these datasets. These correspond to the directory names in alphabetical order."
-   ],
    "metadata": {
     "id": "WLQULyAvJC3X"
-   }
+   },
+   "source": [
+    "You can find the class names in the `class_names` attribute on these datasets. These correspond to the directory names in alphabetical order."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "ZHAxkHX5JD3k"
+   },
+   "outputs": [],
    "source": [
     "class_names = train_ds.class_names\n",
     "print(class_names)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "ZHAxkHX5JD3k"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "_uoVvxSLJW9m"
+   },
    "source": [
     "## Visualize the data\n",
     "\n",
     "Here are the first 9 images from the training dataset."
-   ],
-   "metadata": {
-    "id": "_uoVvxSLJW9m"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "wBmEA9c0JYes"
+   },
+   "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
@@ -355,48 +359,47 @@
     "    plt.imshow(images[i].numpy().astype(\"uint8\"))\n",
     "    plt.title(class_names[labels[i]])\n",
     "    plt.axis(\"off\")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "wBmEA9c0JYes"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "You will train a model using these datasets by passing them to `model.fit` in a moment. If you like, you can also manually iterate over the dataset and retrieve batches of images:"
-   ],
    "metadata": {
     "id": "5M6BXtXFJdW0"
-   }
+   },
+   "source": [
+    "You will train a model using these datasets by passing them to `model.fit` in a moment. If you like, you can also manually iterate over the dataset and retrieve batches of images:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "2-MfMoenJi8s"
+   },
+   "outputs": [],
    "source": [
     "for image_batch, labels_batch in train_ds:\n",
     "  print(image_batch.shape)\n",
     "  print(labels_batch.shape)\n",
     "  break"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "2-MfMoenJi8s"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "Wj4FrKxxJkoW"
+   },
    "source": [
     "The `image_batch` is a tensor of the shape `(32, 180, 180, 3)`. This is a batch of 32 images of shape `180x180x3` (the last dimension refers to color channels RGB). The `label_batch` is a tensor of the shape `(32,)`, these are corresponding labels to the 32 images. \n",
     "\n",
     "You can call `.numpy()` on the `image_batch` and `labels_batch` tensors to convert them to a `numpy.ndarray`.\n"
-   ],
-   "metadata": {
-    "id": "Wj4FrKxxJkoW"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "4Dr0at41KcAU"
+   },
    "source": [
     "## Configure the dataset for performance\n",
     "\n",
@@ -407,119 +410,120 @@
     "`Dataset.prefetch()` overlaps data preprocessing and model execution while training. \n",
     "\n",
     "Interested readers can learn more about both methods, as well as how to cache data to disk in the [data performance guide](https://www.tensorflow.org/guide/data_performance#prefetching)."
-   ],
-   "metadata": {
-    "id": "4Dr0at41KcAU"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "nOjJSm7DKoZA"
+   },
+   "outputs": [],
    "source": [
     "# AUTOTUNE = tf.data.AUTOTUNE\n",
     "AUTOTUNE = tf.data.experimental.AUTOTUNE\n",
     "train_ds = train_ds.cache().shuffle(1000).prefetch(buffer_size=AUTOTUNE)\n",
     "val_ds = val_ds.cache().prefetch(buffer_size=AUTOTUNE)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "nOjJSm7DKoZA"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Standardize the data"
-   ],
    "metadata": {
     "id": "8GUnmPF4JvEf"
-   }
+   },
+   "source": [
+    "## Standardize the data"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "The RGB channel values are in the `[0, 255]` range. This is not ideal for a neural network; in general you should seek to make your input values small. Here, you will standardize values to be in the `[0, 1]` range by using a Rescaling layer."
-   ],
    "metadata": {
     "id": "e56VXHMWJxYT"
-   }
+   },
+   "source": [
+    "The RGB channel values are in the `[0, 255]` range. This is not ideal for a neural network; in general you should seek to make your input values small. Here, you will standardize values to be in the `[0, 1]` range by using a Rescaling layer."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "normalization_layer = layers.experimental.preprocessing.Rescaling(1./255)"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "PEYxo2CTJvY9"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "normalization_layer = layers.experimental.preprocessing.Rescaling(1./255)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Note: The Keras Preprocessing utilities and layers introduced in this section are currently experimental and may change."
-   ],
    "metadata": {
     "id": "8aGpkwFaIw4i"
-   }
+   },
+   "source": [
+    "Note: The Keras Preprocessing utilities and layers introduced in this section are currently experimental and may change."
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "There are two ways to use this layer. You can apply it to the dataset by calling map:"
-   ],
    "metadata": {
     "id": "Bl4RmanbJ4g0"
-   }
+   },
+   "source": [
+    "There are two ways to use this layer. You can apply it to the dataset by calling map:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "X9o9ESaJJ502"
+   },
+   "outputs": [],
    "source": [
     "normalized_ds = train_ds.map(lambda x, y: (normalization_layer(x), y))\n",
     "image_batch, labels_batch = next(iter(normalized_ds))\n",
     "first_image = image_batch[0]\n",
     "# Notice the pixels values are now in `[0,1]`.\n",
     "print(np.min(first_image), np.max(first_image)) "
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "X9o9ESaJJ502"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Or, you can include the layer inside your model definition, which can simplify deployment. Let's use the second approach here."
-   ],
    "metadata": {
     "id": "XWEOmRSBJ9J8"
-   }
+   },
+   "source": [
+    "Or, you can include the layer inside your model definition, which can simplify deployment. Let's use the second approach here."
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Note: you previously resized images using the `image_size` argument of `image_dataset_from_directory`. If you want to include the resizing logic in your model as well, you can use the [Resizing](https://www.tensorflow.org/api_docs/python/tf/keras/layers/experimental/preprocessing/Resizing) layer."
-   ],
    "metadata": {
     "id": "XsRk1xCwKZR4"
-   }
+   },
+   "source": [
+    "Note: you previously resized images using the `image_size` argument of `image_dataset_from_directory`. If you want to include the resizing logic in your model as well, you can use the [Resizing](https://www.tensorflow.org/api_docs/python/tf/keras/layers/experimental/preprocessing/Resizing) layer."
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "WcUTyDOPKucd"
+   },
    "source": [
     "# Create the model\n",
     "\n",
     "The model consists of three convolution blocks with a max pool layer in each of them. There's a fully connected layer with 128 units on top of it that is activated by a `relu` activation function. This model has not been tuned for high accuracy, the goal of this tutorial is to show a standard approach. "
-   ],
-   "metadata": {
-    "id": "WcUTyDOPKucd"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "QR6argA1K074"
+   },
+   "outputs": [],
    "source": [
     "num_classes = 5\n",
     "\n",
@@ -535,72 +539,72 @@
     "  layers.Dense(128, activation='relu'),\n",
     "  layers.Dense(num_classes)\n",
     "])"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "QR6argA1K074"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "EaKFzz72Lqpg"
+   },
    "source": [
     "## Compile the model\n",
     "\n",
     "For this tutorial, choose the `optimizers.Adam` optimizer and `losses.SparseCategoricalCrossentropy` loss function. To view training and validation accuracy for each training epoch, pass the `metrics` argument."
-   ],
-   "metadata": {
-    "id": "EaKFzz72Lqpg"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "jloGNS1MLx3A"
+   },
+   "outputs": [],
    "source": [
     "model.compile(optimizer='adam',\n",
     "              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
     "              metrics=['accuracy'])"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "jloGNS1MLx3A"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "aMJ4DnuJL55A"
+   },
    "source": [
     "## Model summary\n",
     "\n",
     "View all the layers of the network using the model's `summary` method.\n",
     "\n",
     "> **NOTE:** This section is commented out for performance reasons. Please feel free to uncomment these to compare the results."
-   ],
-   "metadata": {
-    "id": "aMJ4DnuJL55A"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "# model.summary()"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "llLYH-BXL7Xe"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "# model.summary()"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Train the model"
-   ],
    "metadata": {
     "id": "NiYHcbvaL9H-"
-   }
+   },
+   "source": [
+    "## Train the model"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "5fWToCqYMErH"
+   },
+   "outputs": [],
    "source": [
     "# epochs=10\n",
     "# history = model.fit(\n",
@@ -608,33 +612,33 @@
     "#   validation_data=val_ds,\n",
     "#   epochs=epochs\n",
     "# )"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "5fWToCqYMErH"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Visualize training results"
-   ],
    "metadata": {
     "id": "SyFKdQpXMJT4"
-   }
+   },
+   "source": [
+    "## Visualize training results"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Create plots of loss and accuracy on the training and validation sets."
-   ],
    "metadata": {
     "id": "dFvOvmAmMK9w"
-   }
+   },
+   "source": [
+    "Create plots of loss and accuracy on the training and validation sets."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "jWnopEChMMCn"
+   },
+   "outputs": [],
    "source": [
     "# acc = history.history['accuracy']\n",
     "# val_acc = history.history['val_accuracy']\n",
@@ -657,68 +661,68 @@
     "# plt.legend(loc='upper right')\n",
     "# plt.title('Training and Validation Loss')\n",
     "# plt.show()"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "jWnopEChMMCn"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "hO_jT7HwMrEn"
+   },
    "source": [
     "As you can see from the plots, training accuracy and validation accuracy are off by large margin and the model has achieved only around 60% accuracy on the validation set.\n",
     "\n",
     "Let's look at what went wrong and try to increase the overall performance of the model."
-   ],
-   "metadata": {
-    "id": "hO_jT7HwMrEn"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Overfitting"
-   ],
    "metadata": {
     "id": "hqtyGodAMvNV"
-   }
+   },
+   "source": [
+    "## Overfitting"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "ixsz9XFfMxcu"
+   },
    "source": [
     "In the plots above, the training accuracy is increasing linearly over time, whereas validation accuracy stalls around 60% in the training process. Also, the difference in accuracy between training and validation accuracy is noticeable—a sign of [overfitting](https://www.tensorflow.org/tutorials/keras/overfit_and_underfit).\n",
     "\n",
     "When there are a small number of training examples, the model sometimes learns from noises or unwanted details from training examples—to an extent that it negatively impacts the performance of the model on new examples. This phenomenon is known as overfitting. It means that the model will have a difficult time generalizing on a new dataset.\n",
     "\n",
     "There are multiple ways to fight overfitting in the training process. In this tutorial, you'll use *data augmentation* and add *Dropout* to your model."
-   ],
-   "metadata": {
-    "id": "ixsz9XFfMxcu"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Data augmentation"
-   ],
    "metadata": {
     "id": "BDMfYqwmM1C-"
-   }
+   },
+   "source": [
+    "## Data augmentation"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "GxYwix81M2YO"
+   },
    "source": [
     "Overfitting generally occurs when there are a small number of training examples. [Data augmentation](https://www.tensorflow.org/tutorials/images/data_augmentation) takes the approach of generating additional training data from your existing examples by augmenting them using random transformations that yield believable-looking images. This helps expose the model to more aspects of the data and generalize better.\n",
     "\n",
     "You will implement data augmentation using the layers from `tf.keras.layers.experimental.preprocessing`. These can be included inside your model like other layers, and run on the GPU."
-   ],
-   "metadata": {
-    "id": "GxYwix81M2YO"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "9J80BAbIMs21"
+   },
+   "outputs": [],
    "source": [
     "data_augmentation = keras.Sequential(\n",
     "  [\n",
@@ -730,24 +734,24 @@
     "    layers.experimental.preprocessing.RandomZoom(0.1),\n",
     "  ]\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "9J80BAbIMs21"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Let's visualize what a few augmented examples look like by applying data augmentation to the same image several times:"
-   ],
    "metadata": {
     "id": "PN4k1dK3S6eV"
-   }
+   },
+   "source": [
+    "Let's visualize what a few augmented examples look like by applying data augmentation to the same image several times:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "7Z90k539S838"
+   },
+   "outputs": [],
    "source": [
     "plt.figure(figsize=(10, 10))\n",
     "for images, _ in train_ds.take(1):\n",
@@ -756,23 +760,22 @@
     "    ax = plt.subplot(3, 3, i + 1)\n",
     "    plt.imshow(augmented_images[0].numpy().astype(\"uint8\"))\n",
     "    plt.axis(\"off\")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "7Z90k539S838"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "You will use data augmentation to train a model in a moment."
-   ],
    "metadata": {
     "id": "tsjXCBLYYNs5"
-   }
+   },
+   "source": [
+    "You will use data augmentation to train a model in a moment."
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "ZeD3bXepYKXs"
+   },
    "source": [
     "## Dropout\n",
     "\n",
@@ -781,14 +784,15 @@
     "When you apply Dropout to a layer it randomly drops out (by setting the activation to zero) a number of output units from the layer during the training process. Dropout takes a fractional number as its input value, in the form such as 0.1, 0.2, 0.4, etc. This means dropping out 10%, 20% or 40% of the output units randomly from the applied layer.\n",
     "\n",
     "Let's create a new neural network using `layers.Dropout`, then train it using augmented images."
-   ],
-   "metadata": {
-    "id": "ZeD3bXepYKXs"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "2Zeg8zsqXCsm"
+   },
+   "outputs": [],
    "source": [
     "model = Sequential([\n",
     "  data_augmentation,\n",
@@ -804,48 +808,48 @@
     "  layers.Dense(128, activation='relu'),\n",
     "  layers.Dense(num_classes)\n",
     "])"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "2Zeg8zsqXCsm"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Compile and train the model"
-   ],
    "metadata": {
     "id": "L4nEcuqgZLbi"
-   }
+   },
+   "source": [
+    "## Compile and train the model"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "EvyAINs9ZOmJ"
+   },
+   "outputs": [],
    "source": [
     "model.compile(optimizer='adam',\n",
     "              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
     "              metrics=['accuracy'])"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "EvyAINs9ZOmJ"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "model.summary()"
-   ],
-   "outputs": [],
    "metadata": {
     "id": "wWLkKoKjZSoC"
-   }
+   },
+   "outputs": [],
+   "source": [
+    "model.summary()"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "LWS-vvNaZDag"
+   },
+   "outputs": [],
    "source": [
     "epochs = 15\n",
     "history = model.fit(\n",
@@ -853,26 +857,26 @@
     "  validation_data=val_ds,\n",
     "  epochs=epochs\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "LWS-vvNaZDag"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "Lkdl8VsBbZOu"
+   },
    "source": [
     "## Visualize training results\n",
     "\n",
     "After applying data augmentation and Dropout, there is less overfitting than before, and training and validation accuracy are closer aligned. "
-   ],
-   "metadata": {
-    "id": "Lkdl8VsBbZOu"
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "dduoLfKsZVIA"
+   },
+   "outputs": [],
    "source": [
     "acc = history.history['accuracy']\n",
     "val_acc = history.history['val_accuracy']\n",
@@ -895,42 +899,43 @@
     "plt.legend(loc='upper right')\n",
     "plt.title('Training and Validation Loss')\n",
     "plt.show()"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "dduoLfKsZVIA"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Predict on new data"
-   ],
    "metadata": {
     "id": "dtv5VbaVb-3W"
-   }
+   },
+   "source": [
+    "## Predict on new data"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Finally, let's use our model to classify an image that wasn't included in the training or validation sets."
-   ],
    "metadata": {
     "id": "10buWpJbcCQz"
-   }
+   },
+   "source": [
+    "Finally, let's use our model to classify an image that wasn't included in the training or validation sets."
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Note: Data augmentation and Dropout layers are inactive at inference time."
-   ],
    "metadata": {
     "id": "NKgMZ4bDcHf7"
-   }
+   },
+   "source": [
+    "Note: Data augmentation and Dropout layers are inactive at inference time."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "id": "dC40sRITBSsQ",
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "sunflower_url = \"https://storage.googleapis.com/download.tensorflow.org/example_images/592px-Red_sunflower.jpg\"\n",
     "sunflower_path = tf.keras.utils.get_file('Red_sunflower', origin=sunflower_url)\n",
@@ -948,43 +953,40 @@
     "    \"This image most likely belongs to {} with a {:.2f} percent confidence.\"\n",
     "    .format(class_names[np.argmax(score)], 100 * np.max(score))\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "dC40sRITBSsQ",
-    "tags": []
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Save the TensorFlow Model"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "#save the trained model - a new folder flower will be created\n",
     "#and the file \"saved_model.pb\" is the pre-trained model\n",
     "model_dir = \"model\"\n",
     "model_fname = f\"{model_dir}/flower\"\n",
     "model.save(model_fname)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Convert the TensorFlow model with OpenVINO Model Optimizer"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# The paths of the source and converted models\n",
     "model_name = \"flower\"\n",
@@ -1007,32 +1009,32 @@
     "mo_command = \" \".join(mo_command.split())\n",
     "print(\"Model Optimizer command to convert TensorFlow to OpenVINO:\")\n",
     "print(mo_command)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Run the Model Optimizer (overwrites the older model)\n",
     "print(\"Exporting TensorFlow model to IR... This may take a few minutes.\")\n",
     "mo_result = %sx $mo_command\n",
     "print(\"\\n\".join(mo_result))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Preprocessing Image Function"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def pre_process_image(imagePath, img_height=180):\n",
     "    # Model input format\n",
@@ -1048,29 +1050,28 @@
     "    input_image = image.reshape((n, c, h, w))\n",
     "\n",
     "    return input_image"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## OpenVINO Inference Engine Setup"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "class_names=[\"daisy\", \"dandelion\", \"roses\", \"sunflowers\", \"tulips\"]\n",
     "\n",
     "model_xml = f\"{model_fname}/flower_ir.xml\"\n",
-    "model_bin = f\"{model_fname}/flower_ir.bin\"\n",
     "\n",
     "# Load network to the plugin\n",
     "ie = IECore()\n",
-    "net = ie.read_network(model=model_xml, weights=model_bin)\n",
+    "net = ie.read_network(model=model_xml)\n",
     "\n",
     "# Neural Compute Stick\n",
     "# exec_net = ie.load_network(network=net, device_name=\"MYRIAD\")\n",
@@ -1080,20 +1081,20 @@
     "\n",
     "input_layer = next(iter(exec_net.input_info))\n",
     "output_layer = next(iter(exec_net.outputs))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Run the Inference Step"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Run the Inference on the Input image...\n",
     "inp_img_url = \"https://upload.wikimedia.org/wikipedia/commons/4/48/A_Close_Up_Photo_of_a_Dandelion.jpg\"\n",
@@ -1120,16 +1121,14 @@
     "    \"This image most likely belongs to {} with a {:.2f} percent confidence.\"\n",
     "    .format(class_names[np.argmax(score)], 100 * np.max(score))\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Thank you! "
-   ],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
The first notebooks used `read_network(model.xml, model.bin)`. Since 2021.3 `read_network(model.xml)` works too (for simple use cases). With this PR, all notebooks use the simpler notation.

In 2021.4 you can often do `load_network("model.xml", "CPU")` and skip the `read_network()` step. We can update the notebooks to use that later.