### PR TITLE
Pin black version to prevent PyPI resolver issues

### DIFF
--- a/.ci/dev-requirements.txt
+++ b/.ci/dev-requirements.txt
@@ -1,6 +1,10 @@
 # Recommended packages for notebook developers
+
 -r ci-requirements.txt      # packages for validation of notebooks
-black                       # format Python code
+
+# black==21.8 requires typing-extensions>3.10 which is incompatible
+# with other packages
+black==21.7b0               # format Python code
 isort                       # sort imports
 jupyterlab-code-formatter   # format code in notebooks in Jupyter Lab
 jupyterlab-git              # checkout and commit code in Jupyter Lab


### PR DESCRIPTION
New version of black, 21.8b0, requires typing-extensions>3.10, which is not compatible with Tensorflow, which requires ~3.7.4. This results in the PyPI resolver trying forever to find compatible requirements. This PR solves that by pinning black to the previous version, 21.7b0