### PR TITLE
Run CI on push to main, add 103 back to CI

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -60,5 +60,5 @@ jobs:
     - name: Analysing with nbval
       run: |
         jupyter lab notebooks --help
-        python -m pytest -x --nbval --durations 10 --reruns 3 --reruns-delay 10 --ignore notebooks/301-tensorflow-training-openvino .
+        python -m pytest -x --nbval --durations 10 --reruns 5 --reruns-delay 20 --ignore notebooks/301-tensorflow-training-openvino .
 

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -11,6 +11,15 @@ on:
     - 'requirements.txt'
     - '.ci/*'
     - '.github/workflows/nbval.yml'
+  push:
+    branches:
+    - 'main'
+    paths:
+    - 'notebooks/**.ipynb'
+    - 'notebooks/**.py'
+    - 'requirements.txt'
+    - '.ci/*'
+    - '.github/workflows/nbval.yml'
   schedule:
     - cron:  '30 8 * * *'
 
@@ -50,4 +59,5 @@ jobs:
     - name: Analysing with nbval
       run: |
         jupyter lab notebooks --help
-        python -m pytest --nbval . --ignore notebooks/103-paddle-onnx-to-openvino --ignore notebooks/301-tensorflow-training-openvino 
+        python -m pytest --nbval . --ignore notebooks/301-tensorflow-training-openvino
+

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -43,6 +43,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r .ci/dev-requirements.txt
+        python -m pip install pytest-rerunfailures
         python -m ipykernel install --user --name openvino_env
         python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Archive pip freeze
@@ -59,5 +60,5 @@ jobs:
     - name: Analysing with nbval
       run: |
         jupyter lab notebooks --help
-        python -m pytest --nbval . --ignore notebooks/301-tensorflow-training-openvino
+        python -m pytest -x --nbval --durations 10 --reruns 3 --reruns-delay 10 --ignore notebooks/301-tensorflow-training-openvino .
 


### PR DESCRIPTION
We currently only run the CI on PR. This is fine when there are few PRs and the process is quick, but things can change between PR approval and merge. Adding a check to run the CI on merge to main.
Also added 103 notebook back to CI. This was removed in #214. Discussed with @Debskij 