### PR TITLE
Add weights to read_model in 004

### DIFF
--- a/notebooks/004-hello-detection/004-hello-detection.ipynb
+++ b/notebooks/004-hello-detection/004-hello-detection.ipynb
@@ -2,76 +2,78 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "01412caf",
+   "metadata": {},
    "source": [
     "# Hello World Text Detection\n",
     "\n",
     "A very basic introduction to OpenVINO that shows how to do text detection on a given IR model.\n",
     "\n",
     "We use the [horizontal-text-detection-0001](https://docs.openvinotoolkit.org/latest/omz_models_model_horizontal_text_detection_0001.html) model from [Open Model Zoo](https://github.com/openvinotoolkit/open_model_zoo/). It detects texts in images and returns blob of data in shape of [100, 5]. For each detection description has format [x_min, y_min, x_max, y_max, conf].\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "740bfdd8",
+   "metadata": {},
    "source": [
     "## Imports"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "73d7aedb",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import cv2\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from openvino.inference_engine import IECore\n",
-    "from os.path import isfile"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "from openvino.inference_engine import IECore"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "85b48949",
+   "metadata": {},
    "source": [
     "## Load the network"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "99737c61",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "ie = IECore()\n",
-    "model_folder = \"model\"\n",
-    "model_name = \"horizontal-text-detection-0001\"\n",
-    "model_extensions = (\"bin\", \"xml\")\n",
-    "\n",
-    "for extension in model_extensions:\n",
-    "    if not isfile(f'{model_folder}/{model_name}.{extension}'):\n",
-    "        raise FileNotFoundError(f\"Missing model file! Please download missing file: {model_name}.{extension}\")\n",
     "\n",
     "net = ie.read_network(\n",
-    "    model=\"model/horizontal-text-detection-0001.xml\"\n",
+    "    model=\"model/horizontal-text-detection-0001.xml\",\n",
+    "    weights=\"model/horizontal-text-detection-0001.bin\",\n",
     ")\n",
     "exec_net = ie.load_network(net, \"CPU\")\n",
     "\n",
     "output_layer_ir = next(iter(exec_net.outputs))\n",
     "input_layer_ir = next(iter(exec_net.input_info))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "705ce668",
+   "metadata": {},
    "source": [
     "## Load an Image"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dc1cfeaf",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Text detection models expects image in BGR format\n",
     "image = cv2.imread(\"data/intel_rnb.jpg\")\n",
@@ -80,114 +82,121 @@
     "N, C, H, W = net.input_info[input_layer_ir].tensor_desc.dims\n",
     "\n",
     "# Resize image to meet network expected input sizes\n",
-    "resized_image = cv2.resize(image, (W, H))  \n",
+    "resized_image = cv2.resize(image, (W, H))\n",
     "\n",
     "# Reshape to network input shape\n",
-    "input_image = np.expand_dims(\n",
-    "    resized_image.transpose(2, 0, 1), 0\n",
-    ")  \n",
+    "input_image = np.expand_dims(resized_image.transpose(2, 0, 1), 0)\n",
     "\n",
-    "plt.imshow(cv2.cvtColor(image, cv2.COLOR_BGR2RGB) )"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "plt.imshow(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f9fcaba9",
+   "metadata": {},
    "source": [
     "## Do Inference"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "363ca630",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "result = exec_net.infer(inputs={input_layer_ir: input_image})\n",
     "\n",
     "# Extract list of boxes from results\n",
-    "boxes = result['boxes']\n",
+    "boxes = result[\"boxes\"]\n",
     "\n",
     "# Remove zero only boxes\n",
-    "boxes = boxes[~np.all(boxes==0, axis=1)]"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "boxes = boxes[~np.all(boxes == 0, axis=1)]"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "09dfac5d",
+   "metadata": {},
    "source": [
     "## Visualize data"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0c6a52b3",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# For each detection, the description has the format: [x_min, y_min, x_max, y_max, conf]\n",
     "# Image passed here is in BGR format with changed width and height. To display it in colors expected by matplotlib we use cvtColor funtion\n",
     "\n",
-    "def convert_result_to_image(bgr_image, resized_image, boxes, threshold=0.3, conf_labels=True): \n",
+    "\n",
+    "def convert_result_to_image(bgr_image, resized_image, boxes, threshold=0.3, conf_labels=True):\n",
     "    # Helper function to multiply shape by ratio\n",
     "    def multiply_by_ratio(ratio_x, ratio_y, box):\n",
-    "        return [max(shape * ratio_y, 10) if idx % 2 else shape * ratio_x for idx, shape in enumerate(box[:-1])]\n",
+    "        return [\n",
+    "            max(shape * ratio_y, 10) if idx % 2 else shape * ratio_x\n",
+    "            for idx, shape in enumerate(box[:-1])\n",
+    "        ]\n",
     "\n",
     "    # Define colors for boxes and descriptions\n",
-    "    colors = {'red': (255, 0, 0), 'green': (0, 255, 0)} \n",
-    " \n",
+    "    colors = {\"red\": (255, 0, 0), \"green\": (0, 255, 0)}\n",
+    "\n",
     "    # Fetch image shapes to calculate ratio\n",
     "    (real_y, real_x), (resized_y, resized_x) = image.shape[:2], resized_image.shape[:2]\n",
-    "    ratio_x, ratio_y = real_x/resized_x, real_y/resized_y\n",
+    "    ratio_x, ratio_y = real_x / resized_x, real_y / resized_y\n",
     "\n",
     "    # Convert base image from bgr to rgb format\n",
-    "    rgb_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2RGB) \n",
+    "    rgb_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2RGB)\n",
     "\n",
     "    # Iterate through non-zero boxes\n",
-    "    for box in boxes: \n",
+    "    for box in boxes:\n",
     "        # Pick confidence factor from last place in array\n",
     "        conf = box[-1]\n",
-    "        if conf > threshold: \n",
+    "        if conf > threshold:\n",
     "            # Convert float to int and multiply position of each box by x and y ratio\n",
-    "            (x_min, y_min, x_max, y_max) = map(int, multiply_by_ratio(ratio_x, ratio_y, box)) \n",
+    "            (x_min, y_min, x_max, y_max) = map(int, multiply_by_ratio(ratio_x, ratio_y, box))\n",
     "\n",
-    "            # Draw box based on position, parameters in rectangle function are: image, start_point, end_point, color, thickness \n",
-    "            rgb_image = cv2.rectangle( \n",
-    "                rgb_image, \n",
-    "                (x_min, y_min), \n",
-    "                (x_max, y_max), \n",
-    "                colors['green'], \n",
-    "                3\n",
-    "            ) \n",
+    "            # Draw box based on position, parameters in rectangle function are: image, start_point, end_point, color, thickness\n",
+    "            rgb_image = cv2.rectangle(rgb_image, (x_min, y_min), (x_max, y_max), colors[\"green\"], 3)\n",
     "\n",
-    "            # Add text to image based on position and confidence, parameters in putText function are: image, text, bottomleft_corner_textfield, font, font_scale, color, thickness, line_type \n",
+    "            # Add text to image based on position and confidence, parameters in putText function are: image, text, bottomleft_corner_textfield, font, font_scale, color, thickness, line_type\n",
     "            if conf_labels:\n",
-    "                rgb_image = cv2.putText( \n",
-    "                    rgb_image, \n",
-    "                    f\"{conf:.2f}\", \n",
-    "                    (x_min, y_min - 10), \n",
-    "                    cv2.FONT_HERSHEY_SIMPLEX, \n",
-    "                    0.8, \n",
-    "                    colors['red'], \n",
-    "                    1, \n",
-    "                    cv2.LINE_AA\n",
-    "                ) \n",
-    "            \n",
+    "                rgb_image = cv2.putText(\n",
+    "                    rgb_image,\n",
+    "                    f\"{conf:.2f}\",\n",
+    "                    (x_min, y_min - 10),\n",
+    "                    cv2.FONT_HERSHEY_SIMPLEX,\n",
+    "                    0.8,\n",
+    "                    colors[\"red\"],\n",
+    "                    1,\n",
+    "                    cv2.LINE_AA,\n",
+    "                )\n",
+    "\n",
     "    return rgb_image"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "plt.figure(figsize=(10,6))\n",
-    "plt.axis('off')\n",
-    "plt.imshow(convert_result_to_image(image, resized_image, boxes, conf_labels=False))"
-   ],
+   "id": "14476f74",
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": [
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.axis(\"off\")\n",
+    "plt.imshow(convert_result_to_image(image, resized_image, boxes, conf_labels=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b97287f-0347-4d1e-8fed-a3189002c230",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
004 adds quite a bit of boilerplate to check if model files already exist. If read_network() is called with just a model parameter and the weights file does not exist, the Jupyter kernel crashes (this only happens if the user deleted the model bin file). But if read_network() is called with both model and weights parameters, an exception is raised if either file doesn't exist, and we can skip all the checking code. Especially for a "hello" notebook, that makes it friendlier to read, and it is more consistent. 

We should revisit the other notebooks too, but to prevent annoying merge conflicts I will not do that all in this PR. 

Code now looks like this:
![image](https://user-images.githubusercontent.com/77325899/131866017-aadffa63-d81e-48f7-a52e-c0e3a3cab3b4.png)
