### PR TITLE
Fix/improve CI issues with 105 and 208

### DIFF
--- a/notebooks/105-language-quantize-bert/105-language-quantize-bert.ipynb
+++ b/notebooks/105-language-quantize-bert/105-language-quantize-bert.ipynb
@@ -84,7 +84,7 @@
    "cell_type": "code",
    "execution_count": null,
    "source": [
-    "download_file(MODEL_LINK, directory=MODEL_DIR)\n",
+    "download_file(MODEL_LINK, directory=MODEL_DIR, show_progress=False)\n",
     "with ZipFile(f'{MODEL_DIR}/{FILE_NAME}', 'r') as zip_ref:\n",
     "    zip_ref.extractall(MODEL_DIR)"
    ],

--- a/notebooks/208-optical-character-recognition/208-optical-character-recognition.ipynb
+++ b/notebooks/208-optical-character-recognition/208-optical-character-recognition.ipynb
@@ -2,25 +2,38 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "a3c3d7f4",
+   "metadata": {},
    "source": [
     "# Optical Character Recognition with OpenVINO\n",
     "\n",
     "This notebook tutorial demonstrates how to perform optical character recognition. It is a continuation of the [004-hello-detection](../004-hello-detection) notebook, which shows text detection only.\n",
     "\n",
     "The [horizontal-text-detection-0001](https://docs.openvinotoolkit.org/latest/omz_models_model_horizontal_text_detection_0001.html) and [text-recognition-resnet](https://docs.openvinotoolkit.org/latest/omz_models_model_text_recognition_resnet_fc.html) models are used together for text detection and then text recognition."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "38a8791e",
+   "metadata": {},
    "source": [
     "## Imports modules required to run"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8fcabe82",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "import cv2\n",
     "import matplotlib.pyplot as plt\n",
@@ -29,25 +42,22 @@
     "from os import path, makedirs, listdir\n",
     "from shutil import copy, copyfileobj\n",
     "from requests import get"
-   ],
-   "outputs": [],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "48a52fad",
+   "metadata": {},
    "source": [
     "## Settings"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "92e378bf",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "ie = IECore()\n",
     "\n",
@@ -59,22 +69,24 @@
     "detection_model_name = \"horizontal-text-detection-0001\"\n",
     "recognition_model_name = \"text-recognition-resnet-fc\"\n",
     "model_extensions = (\"bin\", \"xml\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e7307283",
+   "metadata": {},
    "source": [
     "## Download models and convert public model\n",
     "\n",
     "If it is your first run models will download and convert here. It might take up to ten minutes. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "00ad42ff",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "makedirs(model_folder, exist_ok=True)\n",
     "makedirs(download_folder, exist_ok=True)\n",
@@ -86,7 +98,7 @@
     "            if not path.isfile(f'{download_folder}/{folder_name}/{precision}/{model_name}.{extension}'):\n",
     "                raise FileNotFoundError\n",
     "except FileNotFoundError:\n",
-    "    download_command = f\"omz_downloader --name {detection_model_name},{recognition_model_name} --output_dir {download_folder} --precision {precision}\"\n",
+    "    download_command = f\"omz_downloader --name {detection_model_name},{recognition_model_name} --output_dir {download_folder} --precision {precision} --num_attempts 3\"\n",
     "    convert_command = f\"omz_converter --name {recognition_model_name} --precisions {precision} --download_dir {download_folder} --output_dir {download_folder}\"\n",
     "    # Run commands, first download model than convert it to inferable \n",
     "    !! $download_command\n",
@@ -94,44 +106,54 @@
     "    # Models are downloaded straight to output folder, we will keep all not used files outside of models directory\n",
     "    ! $convert_command\n",
     "    print('Model converted')"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "af27f259",
+   "metadata": {},
    "source": [
     "## Copy models to model folder\n",
     "\n",
     "At this point both models are kept in download_folder (by default named 'output'). We need only .bin and .xml files from there that we will copy to model directory."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b447574b",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "for text_detection_model in listdir(f\"{download_folder}/intel/{detection_model_name}/{precision}\"):\n",
     "    copy(src=f\"{download_folder}/intel/{detection_model_name}/{precision}/{text_detection_model}\", dst=model_folder)\n",
     "\n",
     "for text_recognition_model in listdir(f\"{download_folder}/public/{recognition_model_name}/{precision}\"):\n",
     "    copy(src=f\"{download_folder}/public/{recognition_model_name}/{precision}/{text_recognition_model}\", dst=model_folder)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b12579c5",
+   "metadata": {},
    "source": [
     "## Load the network"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1bba4170",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "net = ie.read_network(\n",
     "    model=f\"{model_folder}/{detection_model_name}.xml\"\n",
@@ -139,27 +161,30 @@
     "exec_net = ie.load_network(net, \"CPU\")\n",
     "\n",
     "input_layer_ir = next(iter(exec_net.input_info))"
-   ],
-   "outputs": [],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "9729bafe",
+   "metadata": {},
    "source": [
     "## Load an Image"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "66495015",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "# Create data folder\n",
     "makedirs(data_folder, exist_ok=True)\n",
@@ -190,29 +215,32 @@
     ")\n",
     "\n",
     "plt.imshow(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))"
-   ],
-   "outputs": [],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "7c2ed960",
+   "metadata": {},
    "source": [
     "## Get boxes\n",
     "\n",
     "It detects texts in images and returns blob of data in shape of [100, 5]. For each detection description has format [x_min, y_min, x_max, y_max, conf]."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f1f7a391",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "result = exec_net.infer(inputs={input_layer_ir: input_image})\n",
     "\n",
@@ -221,18 +249,22 @@
     "\n",
     "# Remove zero only boxes\n",
     "boxes = boxes[~np.all(boxes==0, axis=1)]"
-   ],
-   "outputs": [],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "09025d97",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "def multiply_by_ratio(ratio_x, ratio_y, box):\n",
     "    return [max(shape * ratio_y, 10) if idx % 2 else shape * ratio_x for idx, shape in enumerate(box[:-1])]\n",
@@ -297,18 +329,14 @@
     "                ) \n",
     "            \n",
     "    return rgb_image"
-   ],
-   "outputs": [],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2e4653fc",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "recognition_net = ie.read_network(\n",
     "    model=f\"{model_folder}/{recognition_model_name}.xml\"\n",
@@ -318,13 +346,14 @@
     "\n",
     "recognition_output_layer = next(iter(exec_recognition_net.outputs))\n",
     "recognition_input_layer = next(iter(exec_recognition_net.input_info))\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "409b77d7",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Get height and width of input layer\n",
     "_, _, H, W = recognition_net.input_info[recognition_input_layer].tensor_desc.dims\n",
@@ -366,36 +395,37 @@
     "    annotations.append(''.join(annotation))\n",
     "\n",
     "boxes_with_annotations = zip(boxes, annotations)\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "152458bf",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "plt.imshow(convert_result_to_image(image, resized_image, boxes_with_annotations, conf_labels=True))\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "18e3dcbe",
+   "metadata": {},
    "source": [
     "## Print annotation in text format\n",
     "\n",
     "Print annotations for detected text based on their position in the input image starting from the upper left corner.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "59ea77ce",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "[annotation for _, annotation in sorted(zip(boxes, annotations), key=lambda x: x[0][0]**2 + x[0][1]**2)]"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/utils/notebook_utils.py
+++ b/notebooks/utils/notebook_utils.py
@@ -70,8 +70,8 @@ class DownloadProgressBar:
 
             downloaded = block_num * block_size
             if downloaded < total_size:
-                if block_num % 10 == 0:
-                    # Update progress bar after 10 blocks have been received
+                if block_num % 20 == 0:
+                    # Update progress bar after 20 blocks have been received
                     self.progress_bar.progress = downloaded
                     self.progress_bar.update()
             else:
@@ -139,7 +139,7 @@ def download_ir_model(model_xml_url: str, destination_folder: str = None):
                                files are saved to the current directory
     """
     model_bin_url = model_xml_url[:-4] + ".bin"
-    model_xml_path = download_file(model_xml_url, directory=destination_folder)
+    model_xml_path = download_file(model_xml_url, directory=destination_folder, show_progress=False)
     download_file(model_bin_url, directory=destination_folder)
     return model_xml_path
 


### PR DESCRIPTION
- Temporarily remove progress bar from download_file in 105: this causes issues on macOS with this large file: Jupyter shows many iopub data rate messages.
- Add --num_attempts to model downloader in 208 to make it a bit more robust and try downloading a model file up to three times if it fails (rest of changes in 208 are metadata changes)
- Set progress bar to display a bit less often in notebook_utils to prevent Jupyter iopub errors (this is not enough to fix it for macOS but a more robust default on Windows and Linux). Also minor update to download_model function to only show progress bar on bin download, not xml (since that is usually very small). notebook_utils.py and notebook_utils.ipynb are now in sync.

This is not a real fix for the download issues with 208. The model source file is stored on Google Drive, and sometimes the download limit is reached. 