### PR TITLE
Temporarily remove 208 notebook from CI

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -60,5 +60,5 @@ jobs:
     - name: Analysing with nbval
       run: |
         jupyter lab notebooks --help
-        python -m pytest -x --nbval --durations 10 --reruns 5 --reruns-delay 20 --ignore notebooks/301-tensorflow-training-openvino .
+        python -m pytest -x --nbval --durations 10 --reruns 5 --reruns-delay 20 --ignore notebooks/208-optical-character-recognition --ignore notebooks/301-tensorflow-training-openvino .
 


### PR DESCRIPTION
Model weights are downloaded from Google Drive, which does not work well when there are many automated downloads. Temporarily remove from CI until we can move the model files to more stable storage or switch to another model.