### PR TITLE
Cache files

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -68,5 +68,5 @@ jobs:
     - name: Analysing with nbval
       run: |
         jupyter lab notebooks --help
-        python -m pytest -x --nbval --durations 10 --reruns 5 --reruns-delay 20 --ignore notebooks/208-optical-character-recognition --ignore notebooks/301-tensorflow-training-openvino .
+        python -m pytest -x --nbval --durations 10 --reruns 5 --reruns-delay 70 --ignore notebooks/301-tensorflow-training-openvino .
 

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -68,5 +68,5 @@ jobs:
     - name: Analysing with nbval
       run: |
         jupyter lab notebooks --help
-        python -m pytest -x --nbval --durations 10 --reruns 5 --reruns-delay 70 --ignore notebooks/301-tensorflow-training-openvino .
+        python -m pytest -x --nbval --durations 10 --reruns 5 --reruns-delay 70 --ignore notebooks/208-optical-character-recognition --ignore notebooks/301-tensorflow-training-openvino .
 

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -35,6 +35,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Cache Files
+      id: cache-files
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.paddlehub
+          ~/notebooks/208-optical-character-recognition/output/public/text-recognition-resnet-fc
+        key: cache-files
     - name: Set up Python 
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -41,7 +41,6 @@ jobs:
       with:
         path: |
           ~/.paddlehub
-          ~/notebooks/208-optical-character-recognition/output/public/text-recognition-resnet-fc
         key: cache-files
     - name: Set up Python 
       uses: actions/setup-python@v1


### PR DESCRIPTION
This PR adds a cache to the CI. Currently it caches the ~/.paddlehub folder so that paddlehub does not need to download the file but gets it from the cache. This is not perfect, but better than excluding the 103 notebook from the CI. We can add more granular tests in a future PR. 

After the 208 download works again we can try to include that in the cache too. 

It uses this workflow: https://github.com/actions/cache
Files are cached at the end of the notebook run - so in the CI job for this PR the cache is not filled yet. In subsequent CI runs the cache will be used. 

I also set the rerun delay a bit longer - currently reruns are only useful for failed downloads and waiting a bit over a minute seems better.