### PR TITLE
Run docker_nbval on PR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,13 @@ on:
       - 'notebooks/**.py'
       - 'requirements.txt'
       - '.ci/*requirements.txt'
-
+  pull_request:
+    branches:
+    - 'main'
+    paths:
+      - "Dockerfile"
+      - ".docker/**"
+      - ".github/workflows/docker.yml"
 jobs:
   build:
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,11 @@ name: docker_nbval
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron:  '30 3 * * *'
   push:
+    branches:
+    - 'main'
     paths:
       - "Dockerfile"
       - ".docker/**"


### PR DESCRIPTION
It is currently useless to run docker_nbval on PR's with new notebooks because the Docker image pulls the notebooks from main. But the CI should run when we make a PR with changes to Docker-related files. 