### PR TITLE
Move check README to end of nbval

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -61,9 +61,6 @@ jobs:
     - name: Check install
       run: |
         python check_install.py
-    - name: Check READMEs
-      run: |
-        python -m pytest .ci/test_notebooks.py
     - name: Patch notebooks
       run: |
         python .ci/patch_notebooks.py
@@ -71,4 +68,6 @@ jobs:
       run: |
         jupyter lab notebooks --help
         python -m pytest --nbval -x -k "test_ or notebook_utils" --durations 10 --reruns 5 --reruns-delay 70 --ignore notebooks/208-optical-character-recognition .
-
+    - name: Check READMEs
+      run: |
+        python -m pytest .ci/test_notebooks.py


### PR DESCRIPTION
Move check for README's to the end of nbval so that it is possible to see if a PR notebook works even if no README is added yet.