### PR TITLE
Run apt-get update in convert notebooks CI

### DIFF
--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install required packages
-      run: sudo apt-get install texlive texlive-latex-extra pandoc
+      run: sudo apt-get update && sudo apt install texlive texlive-latex-extra pandoc
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install required packages
-      run: sudo apt-get update && apt-get install texlive texlive-latex-extra pandoc
+      run: sudo apt-get update && sudo apt-get install texlive texlive-latex-extra pandoc
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install required packages
-      run: sudo apt-get install texlive texlive-latex-extra pandoc
+      run: sudo apt-get update && apt-get install texlive texlive-latex-extra pandoc
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -7,7 +7,14 @@ on:
     branches:
     - 'main'
     paths:
-    - "**.ipynb"
+    - 'notebooks/**.ipynb'
+    - 'notebooks/**.py'
+    - 'requirements.txt'
+    - '.ci/*'
+    - '.github/workflows/convert_notebooks.yml'
+  pull_request:
+    paths:
+    - '.github/workflows/convert_notebooks.yml'    
 jobs:
   build:
     strategy:
@@ -20,7 +27,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install required packages
-      run: sudo apt-get update && sudo apt install texlive texlive-latex-extra pandoc
+      run: sudo apt-get install texlive texlive-latex-extra pandoc
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
CI job for converting notebooks currently fails on installing latex packages (required for rst conversion). This PR adds apt-get update before installing these packages to fix that. The yml file is also modified so that the CI job runs when .py files or requirements are changed, and on a PR where this yml file is changed.