### PR TITLE
Remove unused imports, fix global variable in 104

### DIFF
--- a/notebooks/104-model-tools/104-model-tools.ipynb
+++ b/notebooks/104-model-tools/104-model-tools.ipynb
@@ -76,12 +76,10 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "import os.path\n",
-    "import subprocess\n",
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "from IPython.display import Markdown\n",
+    "from IPython.display import Markdown, display\n",
     "from openvino.inference_engine import IECore\n",
     "\n",
     "sys.path.append(\"../utils\")\n",
@@ -247,7 +245,7 @@
     "        \"`selected_model_info` in the cell below to select a different model from the list.\",\n",
     "        \"warning\",\n",
     "    )\n",
-    "    \n",
+    "\n",
     "model_info"
    ]
   },
@@ -353,18 +351,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def benchmark_model(model, device=\"CPU\", seconds=60, api=\"async\", batch=1):\n",
+    "def benchmark_model(model_xml, device=\"CPU\", seconds=60, api=\"async\", batch=1):\n",
     "    ie = IECore()\n",
-    "    \n",
+    "    model_path = Path(model_xml)\n",
     "    if (\"GPU\" in device) and (\"GPU\" not in ie.available_devices):\n",
     "        DeviceNotFoundAlert(\"GPU\")\n",
     "    else:\n",
     "        benchmark_command = f\"benchmark_app -m {model_path} -d {device} -t {seconds} -api {api} -b {batch}\"\n",
-    "        display(Markdown(f\"**Benchmark {model_name} with {device} for {seconds} seconds with {api} inference**\"))\n",
+    "        display(Markdown(f\"**Benchmark {model_path.name} with {device} for {seconds} seconds with {api} inference**\"))\n",
     "        display(Markdown(f\"Benchmark command: `{benchmark_command}`\"))\n",
     "\n",
     "        benchmark_output = %sx $benchmark_command\n",
-    "        benchmark_result = [line for line in benchmark_output if not (line.startswith(r\"[\") or line.startswith(\"  \") or line==\"\")]\n",
+    "        benchmark_result = [line for line in benchmark_output\n",
+    "                            if not (line.startswith(r\"[\") or line.startswith(\"  \") or line == \"\")]\n",
     "        print(\"\\n\".join(benchmark_result))"
    ]
   },
@@ -460,7 +459,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The benchmark_model function used global variables defined outside the scope of the function. This PR fixes that, and removes unused imports.