### PR TITLE
Enable progress bar for download of MRPC.zip in 105

### DIFF
--- a/notebooks/105-language-quantize-bert/105-language-quantize-bert.ipynb
+++ b/notebooks/105-language-quantize-bert/105-language-quantize-bert.ipynb
@@ -95,7 +95,7 @@
    },
    "outputs": [],
    "source": [
-    "download_file(MODEL_LINK, directory=MODEL_DIR, show_progress=False)\n",
+    "download_file(MODEL_LINK, directory=MODEL_DIR, show_progress=True)\n",
     "with ZipFile(f\"{MODEL_DIR}/{FILE_NAME}\", \"r\") as zip_ref:\n",
     "    zip_ref.extractall(MODEL_DIR)"
    ]


### PR DESCRIPTION
Progress bar was temporarily removed from 105 because it did not always work well on macOS. A new progress bar was added in #235 that should fix this issue, so the progress bar can be enabled again.