### PR TITLE
Add model caching to 002 notebook

### DIFF
--- a/notebooks/002-openvino-api/002-openvino-api.ipynb
+++ b/notebooks/002-openvino-api/002-openvino-api.ipynb
@@ -26,6 +26,7 @@
     "- [Reshaping and Resizing](#Reshaping-and-Resizing)\n",
     "  - [Change Image Size](#Change-Image-Size)\n",
     "  - [Change Batch Size](#Change-Batch-Size)\n",
+    " - [Caching a Model](#Caching-a-Model)\n",
     "    \n",
     "The notebook is divided into sections with headers. Each section is standalone and does not depend on previous sections. A segmentation and classification IR model and a segmentation ONNX model are provided as examples. You can replace these model files with your own models. The exact outputs will be different, but the process is the same. "
    ]
@@ -383,9 +384,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "input_data = np.expand_dims(np.transpose(resized_image, (2, 0, 1)), 0).astype(\n",
-    "    np.float32\n",
-    ")\n",
+    "input_data = np.expand_dims(np.transpose(resized_image, (2, 0, 1)), 0).astype(np.float32)\n",
     "input_data.shape"
    ]
   },
@@ -474,9 +473,7 @@
     "\n",
     "print(\"~~~~ ORIGINAL MODEL ~~~~\")\n",
     "print(f\"input layout: {segmentation_net.input_info[segmentation_input_layer].layout}\")\n",
-    "print(\n",
-    "    f\"input shape: {segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims}\"\n",
-    ")\n",
+    "print(f\"input shape: {segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims}\")\n",
     "print(f\"output shape: {segmentation_net.outputs[segmentation_output_layer].shape}\")\n",
     "\n",
     "new_shape = (1, 3, 544, 544)\n",
@@ -484,9 +481,7 @@
     "segmentation_exec_net = ie.load_network(network=segmentation_net, device_name=\"CPU\")\n",
     "\n",
     "print(\"~~~~ RESHAPED MODEL ~~~~\")\n",
-    "print(\n",
-    "    f\"net input shape: {segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims}\"\n",
-    ")\n",
+    "print(f\"net input shape: {segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims}\")\n",
     "print(\n",
     "    f\"exec_net input shape: \"\n",
     "    f\"{segmentation_exec_net.input_info[segmentation_input_layer].tensor_desc.dims}\"\n",
@@ -536,9 +531,7 @@
     "segmentation_exec_net = ie.load_network(network=segmentation_net, device_name=\"CPU\")\n",
     "\n",
     "print(f\"input layout: {segmentation_net.input_info[segmentation_input_layer].layout}\")\n",
-    "print(\n",
-    "    f\"input shape: {segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims}\"\n",
-    ")\n",
+    "print(f\"input shape: {segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims}\")\n",
     "print(f\"output shape: {segmentation_net.outputs[segmentation_output_layer].shape}\")"
    ]
   },
@@ -565,9 +558,7 @@
     "segmentation_net = ie.read_network(model=segmentation_model_xml)\n",
     "segmentation_input_layer = next(iter(segmentation_net.input_info))\n",
     "segmentation_output_layer = next(iter(segmentation_net.outputs))\n",
-    "input_data = np.random.rand(\n",
-    "    *segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims\n",
-    ")\n",
+    "input_data = np.random.rand(*segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims)\n",
     "segmentation_net.batch_size = 2\n",
     "segmentation_exec_net = ie.load_network(network=segmentation_net, device_name=\"CPU\")\n",
     "result_batch = segmentation_exec_net.infer({segmentation_input_layer: input_data})\n",
@@ -602,14 +593,75 @@
     "segmentation_input_layer = next(iter(segmentation_net.input_info))\n",
     "segmentation_output_layer = next(iter(segmentation_net.outputs))\n",
     "segmentation_net.batch_size = 2\n",
-    "input_data = np.random.rand(\n",
-    "    *segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims\n",
-    ")\n",
+    "input_data = np.random.rand(*segmentation_net.input_info[segmentation_input_layer].tensor_desc.dims)\n",
     "segmentation_exec_net = ie.load_network(network=segmentation_net, device_name=\"CPU\")\n",
     "result_batch = segmentation_exec_net.infer({segmentation_input_layer: input_data})\n",
     "\n",
     "print(f\"input data shape: {input_data.shape}\")\n",
     "print(f\"result data shape: {result_batch[segmentation_output_layer].shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9657dc5-9713-4d2b-a324-c8cd6195e79a",
+   "metadata": {},
+   "source": [
+    "## Caching a Model\n",
+    "\n",
+    "For some devices, like GPU, loading a model can take some time. Model Caching solves this issue by caching the model in a cache directory. If `ie.set_config({\"CACHE_DIR\": cache_dir}, device_name=device_name)` is set, caching will be used. This option checks if a model exists in the cache. If so, it loads it from the cache. If not, it loads the model regularly, and stores it in the cache, so that the next time the model is loaded when this option is set, the model will be loaded from the cache.\n",
+    "\n",
+    "In the cell below, we create a *model_cache* directory as a subdirectory of *model*, where the model will be cached for the specified device. The model will be loaded to the GPU if a GPU device is available, otherwise it will use the CPU device. After running this cell once, the model will be cached, so subsequent runs of this cell will load the model from the cache."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d235185-18f7-4cf0-8cb2-1ecba279318a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from openvino.inference_engine import IECore\n",
+    "\n",
+    "ie = IECore()\n",
+    "device_name = \"GPU\" if \"GPU\" in ie.available_devices else \"CPU\"\n",
+    "cache_path = Path(\"model/model_cache\")\n",
+    "cache_path.mkdir(exist_ok=True)\n",
+    "# Enable caching for Inference Engine. Comment out this line to disable caching\n",
+    "ie.set_config({\"CACHE_DIR\": str(cache_path)}, device_name=device_name)\n",
+    "\n",
+    "classification_model_xml = \"model/classification.xml\"\n",
+    "net = ie.read_network(model=classification_model_xml)\n",
+    "\n",
+    "start_time = time.perf_counter()\n",
+    "exec_net = ie.load_network(network=net, device_name=device_name)\n",
+    "end_time = time.perf_counter()\n",
+    "print(f\"Loading the network to the {device_name} device took {end_time-start_time:.2f} seconds.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48e0a860-c93c-4b93-a684-f53cd66ec2e3",
+   "metadata": {},
+   "source": [
+    "After running the previous cell, we know the model exists in the cache directory. We delete exec net and load it again, and measure the time it takes now."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5a7686b-b9e0-44a6-8b6e-5b299d085eac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del exec_net\n",
+    "start_time = time.perf_counter()\n",
+    "exec_net = ie.load_network(network=net, device_name=device_name)\n",
+    "end_time = time.perf_counter()\n",
+    "print(f\"Loading the network to the {device_name} device took {end_time-start_time:.2f} seconds.\")"
    ]
   }
  ],

--- a/notebooks/002-openvino-api/002-openvino-api.ipynb
+++ b/notebooks/002-openvino-api/002-openvino-api.ipynb
@@ -610,7 +610,7 @@
     "\n",
     "For some devices, like GPU, loading a model can take some time. Model Caching solves this issue by caching the model in a cache directory. If `ie.set_config({\"CACHE_DIR\": cache_dir}, device_name=device_name)` is set, caching will be used. This option checks if a model exists in the cache. If so, it loads it from the cache. If not, it loads the model regularly, and stores it in the cache, so that the next time the model is loaded when this option is set, the model will be loaded from the cache.\n",
     "\n",
-    "In the cell below, we create a *model_cache* directory as a subdirectory of *model*, where the model will be cached for the specified device. The model will be loaded to the GPU if a GPU device is available, otherwise it will use the CPU device. After running this cell once, the model will be cached, so subsequent runs of this cell will load the model from the cache."
+    "In the cell below, we create a *model_cache* directory as a subdirectory of *model*, where the model will be cached for the specified device. The model will be loaded to the GPU. After running this cell once, the model will be cached, so subsequent runs of this cell will load the model from the cache. Note: Model Caching is not available on CPU devices"
    ]
   },
   {
@@ -627,19 +627,24 @@
     "from openvino.inference_engine import IECore\n",
     "\n",
     "ie = IECore()\n",
-    "device_name = \"GPU\" if \"GPU\" in ie.available_devices else \"CPU\"\n",
-    "cache_path = Path(\"model/model_cache\")\n",
-    "cache_path.mkdir(exist_ok=True)\n",
-    "# Enable caching for Inference Engine. Comment out this line to disable caching\n",
-    "ie.set_config({\"CACHE_DIR\": str(cache_path)}, device_name=device_name)\n",
     "\n",
-    "classification_model_xml = \"model/classification.xml\"\n",
-    "net = ie.read_network(model=classification_model_xml)\n",
+    "device_name = \"GPU\"  # Model Caching is not available for CPU\n",
     "\n",
-    "start_time = time.perf_counter()\n",
-    "exec_net = ie.load_network(network=net, device_name=device_name)\n",
-    "end_time = time.perf_counter()\n",
-    "print(f\"Loading the network to the {device_name} device took {end_time-start_time:.2f} seconds.\")"
+    "if device_name in ie.available_devices and device_name != \"CPU\":\n",
+    "    cache_path = Path(\"model/model_cache\")\n",
+    "    cache_path.mkdir(exist_ok=True)\n",
+    "    # Enable caching for Inference Engine. Comment out this line to disable caching\n",
+    "    ie.set_config({\"CACHE_DIR\": str(cache_path)}, device_name=device_name)\n",
+    "\n",
+    "    classification_model_xml = \"model/classification.xml\"\n",
+    "    net = ie.read_network(model=classification_model_xml)\n",
+    "\n",
+    "    start_time = time.perf_counter()\n",
+    "    exec_net = ie.load_network(network=net, device_name=device_name)\n",
+    "    end_time = time.perf_counter()\n",
+    "    print(f\"Loading the network to the {device_name} device took {end_time-start_time:.2f} seconds.\")\n",
+    "else:\n",
+    "    print(\"Model caching is not available on GPU devices.\")"
    ]
   },
   {
@@ -657,12 +662,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "del exec_net\n",
-    "start_time = time.perf_counter()\n",
-    "exec_net = ie.load_network(network=net, device_name=device_name)\n",
-    "end_time = time.perf_counter()\n",
-    "print(f\"Loading the network to the {device_name} device took {end_time-start_time:.2f} seconds.\")"
+    "if device_name in ie.available_devices and device_name != \"CPU\":\n",
+    "    del exec_net\n",
+    "    start_time = time.perf_counter()\n",
+    "    exec_net = ie.load_network(network=net, device_name=device_name)\n",
+    "    end_time = time.perf_counter()\n",
+    "    print(f\"Loading the network to the {device_name} device took {end_time-start_time:.2f} seconds.\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b21fb052-67df-48b1-adee-a636acf43b6f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Add model caching cell to API tutorial. 

I fixed it to GPU device for now because caching is not available for CPU and we have not covered other devices anywhere yet. I can expand this later.

There are a few style updates in the diff too (from black) - the only content I added is the final section and an entry to the table of contents.