### PR TITLE
Fix typo in 002 notebook

### DIFF
--- a/notebooks/002-openvino-api/002-openvino-api.ipynb
+++ b/notebooks/002-openvino-api/002-openvino-api.ipynb
@@ -644,7 +644,7 @@
     "    end_time = time.perf_counter()\n",
     "    print(f\"Loading the network to the {device_name} device took {end_time-start_time:.2f} seconds.\")\n",
     "else:\n",
-    "    print(\"Model caching is not available on GPU devices.\")"
+    "    print(\"Model caching is not available on CPU devices.\")"
    ]
   },
   {


### PR DESCRIPTION
Model Caching is not available on CPU devices instead of GPU (typo in print statement, not code)