### PR TITLE
Start notebooks in Docker image from root dir instead of notebooks dir

### DIFF
--- a/.docker/start-notebook.sh
+++ b/.docker/start-notebook.sh
@@ -65,4 +65,4 @@ if [ -f /opt/app-root/src/.jupyter/jupyter_notebook_config.sh ]; then
     . /opt/app-root/src/.jupyter/jupyter_notebook_config.sh
 fi
 
-exec /opt/app-root/bin/start.sh $JUPYTER_PROGRAM $JUPYTER_PROGRAM_ARGS openvino_notebooks/notebooks "$@"
+exec /opt/app-root/bin/start.sh $JUPYTER_PROGRAM $JUPYTER_PROGRAM_ARGS "$@"


### PR DESCRIPTION
This PR should fix #274  (see issue for problem description and solution). 
![image](https://user-images.githubusercontent.com/77325899/135286795-1bf408e8-bb44-45ad-85ae-114b9c655c25.png)
