### PR TITLE
Cache openvino pip files in CI

### DIFF
--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -21,6 +21,17 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
+    - name: Cache Pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: Linux-3.7-cache
+    - name: Cache Files
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.paddlehub
+        key: cache-files
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v1
@@ -60,3 +71,8 @@ jobs:
       with:
         name: rst_files
         path: rst_files
+    - name: Cache openvino pip files
+      run: |
+        pip cache purge # Cache only openvino files, not other dependencies
+        pip download openvino==2021.4.1 openvino-dev==2021.4.1 openvino-extensions==2021.4.1 --no-deps
+

--- a/.github/workflows/install_requirements.yml
+++ b/.github/workflows/install_requirements.yml
@@ -5,16 +5,32 @@ on:
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
         python: [3.6, 3.7, 3.8]
-
-    runs-on: ${{ matrix.os }}
+        include:
+        - os: ubuntu-18.04
+          pip_cache_path: ~/.cache/pip
+        - os: ubuntu-20.04
+          pip_cache_path: ~/.cache/pip
+        - os: macos-latest
+          pip_cache_path: ~/Library/Caches/pip
+        - os: windows-latest
+          pip_cache_path: ~\AppData\Local\pip\Cache
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Cache Files
+      uses: actions/cache@v2
+      with:
+        path: ${{ matrix.pip_cache_path }}
+        key: ${{ runner.os }}-${{ matrix.python }}-cache
+
+    - name: Checkout
+      uses: actions/checkout@v2
+ 
     - name: Set up Python 
       uses: actions/setup-python@v1
       with:
@@ -33,3 +49,8 @@ jobs:
     - name: Test that `jupyter lab` works
       run: |
         jupyter lab notebooks --help
+    - name: Cache openvino pip files
+      run: |
+        pip cache purge # Cache only openvino files, not other dependencies
+        pip download openvino==2021.4.1 openvino-dev==2021.4.1 openvino-extensions==2021.4.1 --no-deps
+

--- a/.github/workflows/install_requirements.yml
+++ b/.github/workflows/install_requirements.yml
@@ -2,6 +2,11 @@ name: install_requirements
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+    - 'main'
+    paths:
+    - '.github/workflows/install_requirements.yml'
 
 jobs:
   build:

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -25,23 +25,35 @@ on:
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
         python: [3.6, 3.7, 3.8]
-
-    runs-on: ${{ matrix.os }}
-
+        include:
+        - os: ubuntu-18.04
+          pip_cache_path: ~/.cache/pip
+        - os: ubuntu-20.04
+          pip_cache_path: ~/.cache/pip
+        - os: macos-latest
+          pip_cache_path: ~/Library/Caches/pip
+        - os: windows-latest
+          pip_cache_path: ~\AppData\Local\pip\Cache
     steps:
-    - uses: actions/checkout@v2
+    - name: Cache Pip
+      uses: actions/cache@v2
+      with:
+        path: ${{ matrix.pip_cache_path }}
+        key: ${{ runner.os }}-${{ matrix.python }}-cache
     - name: Cache Files
-      id: cache-files
       uses: actions/cache@v2
       with:
         path: |
           ~/.paddlehub
         key: cache-files
+    - name: Checkout repository
+      uses: actions/checkout@v2
     - name: Set up Python 
       uses: actions/setup-python@v1
       with:
@@ -69,3 +81,7 @@ jobs:
     - name: Analysing with nbval
       run: |
         python -m pytest --nbval -x -k "test_ or notebook_utils" --durations 10 --ignore notebooks/208-optical-character-recognition .
+    - name: Cache openvino pip files
+      run: |
+        pip cache purge # Cache only openvino files, not other dependencies
+        pip download openvino==2021.4.1 openvino-dev==2021.4.1 openvino-extensions==2021.4.1 --no-deps


### PR DESCRIPTION
Cache openvino pip files in Github Actions so they do not get downloaded every CI run.
I only cache the openvino files (openvino, openvino-dev, openvino-extensions) and not the other requirements/dependencies because a) that would exceed the github actions cache limit and b) that would risk us missing issues with dependencies because they are downloaded from the cache.

For now I hardcoded the OpenVINO version in the cache, meaning we'll have to update this file (and the cache key) with a new OpenVINO release. This is not ideal, but not the only thing we manually change with a new release. We can improve this later.
