### PR TITLE
Update to remove the git pull since it can cause crashes

### DIFF
--- a/.docker/builder/run
+++ b/.docker/builder/run
@@ -44,14 +44,15 @@ if [ -n "${JUPYTER_PRELOAD_REPOS}" ]; then
         fi
         echo "Checking if repository $repo exists locally"
         REPO_DIR=$(basename ${repo})
-        if [ -d "${REPO_DIR}" ]; then
-            pushd ${REPO_DIR}
-            GIT_SSL_NO_VERIFY=true git pull --ff-only
-            popd
-        else
+        if ! [ -d "${REPO_DIR}" ]; then
             GIT_SSL_NO_VERIFY=true git clone ${repo} ${REPO_DIR} ${REPO_BRANCH}
         fi
     done
+fi
+
+# Copy notebooks onto the user volume if they don't exist
+if [ -d /opt/app-root/notebooks ] && ! [ -d /opt/app-root/src/openvino_notebooks ]; then
+  cp -r /opt/app-root/notebooks /opt/app-root/src/openvino_notebooks
 fi
 
 # Start the Jupyter notebook instance. Run using supervisord if enabled,

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ ENV JUPYTER_ENABLE_LAB="true" \
   THOTH_DRY_RUN="1" \
   THAMOS_DEBUG="0" \
   THAMOS_VERBOSE="1" \
-  THOTH_PROVENANCE_CHECK="0" \
-  JUPYTER_PRELOAD_REPOS="https://github.com/openvinotoolkit/openvino_notebooks"
+  THOTH_PROVENANCE_CHECK="0"
 
 USER root
 
@@ -44,6 +43,8 @@ RUN dos2unix /tmp/src/builder/*
 # Change file ownership to the assemble user. Builder image must support chown command.
 RUN chown -R 1001:0 /tmp/scripts /tmp/src
 USER 1001
+RUN mkdir /opt/app-root/notebooks
+COPY notebooks/ /opt/app-root/notebooks
 RUN /tmp/scripts/assemble
 RUN pip check
 USER root


### PR DESCRIPTION
Resolves https://github.com/openvinotoolkit/openvino_notebooks/issues/273
This handles the issue with git pull crashing a container if there's a merge conflict

It instead places the notebooks in /opt/app-root/notebooks, and copies them into ~/openvino_notebooks at runtime if the directory doesn't already exist

This also has the benefit of locking the notebooks to the current version. Once a git push can trigger a rebuild, the loop will be closed on maintenance