### PR TITLE
208-add spinner, change download dir, visualize boxes

### DIFF
--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -41,7 +41,7 @@ jobs:
         python -m ipykernel install --user --name openvino_env
     - name: Flake8
       run: |
-        nbqa flake8 --ignore=E124,E203,E266,E402,E501,F821,W503,W291,W293 --nbqa-exclude="(301.*)|(302.*)|(208.*)" notebooks
+        nbqa flake8 --ignore=E124,E203,E266,E402,E501,E703,F821,W503,W291,W293 --nbqa-exclude="(301.*)|(302.*)" notebooks
     - name: Check READMEs
       run: |
         python -m pytest .ci/test_notebooks.py

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -51,6 +51,7 @@ jobs:
       with:
         path: |
           ~/.paddlehub
+          ~/open_model_zoo_cache
         key: cache-files
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -80,7 +81,7 @@ jobs:
         jupyter lab notebooks --help
     - name: Analysing with nbval
       run: |
-        python -m pytest --nbval -x -k "test_ or notebook_utils" --durations 10 --ignore notebooks/208-optical-character-recognition .
+        python -m pytest --nbval -x -k "test_ or notebook_utils" --durations 10
     - name: Cache openvino pip files
       run: |
         pip cache purge # Cache only openvino files, not other dependencies

--- a/notebooks/208-optical-character-recognition/208-optical-character-recognition.ipynb
+++ b/notebooks/208-optical-character-recognition/208-optical-character-recognition.ipynb
@@ -7,9 +7,11 @@
    "source": [
     "# Optical Character Recognition with OpenVINO\n",
     "\n",
-    "This notebook tutorial demonstrates how to perform optical character recognition. It is a continuation of the [004-hello-detection](../004-hello-detection) notebook, which shows text detection only.\n",
+    "This notebook tutorial demonstrates how to perform optical character recognition with OpenVINO models. It is a continuation of the [004-hello-detection](../004-hello-detection) notebook, which shows text detection only.\n",
     "\n",
-    "The [horizontal-text-detection-0001](https://docs.openvinotoolkit.org/latest/omz_models_model_horizontal_text_detection_0001.html) and [text-recognition-resnet](https://docs.openvinotoolkit.org/latest/omz_models_model_text_recognition_resnet_fc.html) models are used together for text detection and then text recognition."
+    "The [horizontal-text-detection-0001](https://docs.openvinotoolkit.org/latest/omz_models_model_horizontal_text_detection_0001.html) and [text-recognition-resnet](https://docs.openvinotoolkit.org/latest/omz_models_model_text_recognition_resnet_fc.html) models are used together for text detection and then text recognition.\n",
+    "\n",
+    "In this notebook, Open Model Zoo tools Model Downloader, Model Converter and Info Dumper are used to download and convert the models from [Open Model Zoo](https://github.com/openvinotoolkit/open_model_zoo). See the [104-model-tools](../104-model-tools/104-model-tools.ipynb) notebook for more information about these tools."
    ]
   },
   {
@@ -17,7 +19,7 @@
    "id": "38a8791e",
    "metadata": {},
    "source": [
-    "## Imports modules required to run"
+    "## Imports"
    ]
   },
   {
@@ -35,13 +37,21 @@
    },
    "outputs": [],
    "source": [
+    "import json\n",
+    "import shutil\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
     "import cv2\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
+    "from IPython.display import Markdown, display\n",
     "from openvino.inference_engine import IECore\n",
-    "from os import path, makedirs, listdir\n",
-    "from shutil import copy, copyfileobj\n",
-    "from requests import get"
+    "from PIL import Image\n",
+    "from yaspin import yaspin\n",
+    "\n",
+    "sys.path.append(\"../utils\")\n",
+    "from notebook_utils import load_image"
    ]
   },
   {
@@ -61,14 +71,14 @@
    "source": [
     "ie = IECore()\n",
     "\n",
-    "model_folder = \"model\"\n",
-    "download_folder = \"output\"\n",
-    "data_folder = \"data\"\n",
-    "\n",
+    "model_dir = Path(\"model\")\n",
     "precision = \"FP16\"\n",
-    "detection_model_name = \"horizontal-text-detection-0001\"\n",
-    "recognition_model_name = \"text-recognition-resnet-fc\"\n",
-    "model_extensions = (\"bin\", \"xml\")"
+    "detection_model = \"horizontal-text-detection-0001\"\n",
+    "recognition_model = \"text-recognition-resnet-fc\"\n",
+    "base_model_dir = Path(\"~/open_model_zoo_models\").expanduser()\n",
+    "omz_cache_dir = Path(\"~/open_model_zoo_cache\").expanduser()\n",
+    "\n",
+    "model_dir.mkdir(exist_ok=True)"
    ]
   },
   {
@@ -76,68 +86,110 @@
    "id": "e7307283",
    "metadata": {},
    "source": [
-    "## Download models and convert public model\n",
+    "## Download Models\n",
     "\n",
-    "If it is your first run models will download and convert here. It might take up to ten minutes. "
+    "The next cells will run Open Model Zoo's Model Downloader to download the detection and recognition models that are used in this notebook. If the models have been downloaded before, they will not be downloaded again."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00ad42ff",
+   "id": "ed249c63-33b9-4def-903e-9f15a53bbd82",
    "metadata": {},
    "outputs": [],
    "source": [
-    "makedirs(model_folder, exist_ok=True)\n",
-    "makedirs(download_folder, exist_ok=True)\n",
+    "download_command = f\"omz_downloader --name {detection_model},{recognition_model} --output_dir {base_model_dir} --cache_dir {omz_cache_dir} --precision {precision} --num_attempts 3\"\n",
+    "display(Markdown(f\"Download command: `{download_command}`\"))\n",
+    "with yaspin(text=f\"Downloading {detection_model}, {recognition_model}\") as sp:\n",
+    "    download_result = !$download_command\n",
+    "    sp.text = f\"Finished downloading {detection_model}, {recognition_model}\"\n",
+    "    sp.ok(\"✔\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5586f3a-2442-42d1-899c-39c0b452dcfe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### The text-recognition-resnet-fc model consists of many files. All filenames are printed in\n",
+    "### Model Downloader's output. Uncomment the next two lines to show this output\n",
     "\n",
-    "# Check if models are already downloaded in download directory\n",
-    "try:\n",
-    "    for model_name, folder_name in ((detection_model_name, f'intel/{detection_model_name}'), (recognition_model_name, f'public/{recognition_model_name}')):\n",
-    "        for extension in model_extensions:\n",
-    "            if not path.isfile(f'{download_folder}/{folder_name}/{precision}/{model_name}.{extension}'):\n",
-    "                raise FileNotFoundError\n",
-    "except FileNotFoundError:\n",
-    "    download_command = f\"omz_downloader --name {detection_model_name},{recognition_model_name} --output_dir {download_folder} --precision {precision} --num_attempts 3\"\n",
-    "    convert_command = f\"omz_converter --name {recognition_model_name} --precisions {precision} --download_dir {download_folder} --output_dir {download_folder}\"\n",
-    "    # Run commands, first download model than convert it to inferable \n",
-    "    !! $download_command\n",
-    "    print('Models downloded')\n",
-    "    # Models are downloaded straight to output folder, we will keep all not used files outside of models directory\n",
-    "    ! $convert_command\n",
-    "    print('Model converted')"
+    "# for line in download_result:\n",
+    "#    print(line)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "af27f259",
+   "id": "ec25afa0-55b0-488d-98ad-07b3bdfb1dc9",
    "metadata": {},
    "source": [
-    "## Copy models to model folder\n",
+    "## Convert Models\n",
     "\n",
-    "At this point both models are kept in download_folder (by default named 'output'). We need only .bin and .xml files from there that we will copy to model directory."
+    "The downloaded detection model is an Intel model, which is already in OpenVINO's Intermediate Representation (IR) format. The text recognition model is a public model which needs to be converted to IR. Since this model was downloaded from Open Model Zoo we can use Model Converter to convert the model to IR format.\n",
+    "\n",
+    "Model Converter output will be displayed. Conversion was succesful if the last lines of output include `[ SUCCESS ] Generated IR version 10 model.`"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b447574b",
+   "id": "d848c9c3-1baa-4494-94be-afea85c7ea98",
    "metadata": {},
    "outputs": [],
    "source": [
-    "for text_detection_model in listdir(f\"{download_folder}/intel/{detection_model_name}/{precision}\"):\n",
-    "    copy(src=f\"{download_folder}/intel/{detection_model_name}/{precision}/{text_detection_model}\", dst=model_folder)\n",
+    "convert_command = f\"omz_converter --name {recognition_model} --precisions {precision} --download_dir {base_model_dir} --output_dir {base_model_dir}\"\n",
+    "display(Markdown(f\"Convert command: `{convert_command}`\"))\n",
+    "display(Markdown(f\"Converting {recognition_model}...\"))\n",
+    "! $convert_command"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3fb1042-0877-458d-99b9-b21d847e4f54",
+   "metadata": {},
+   "source": [
+    "## Copy Models\n",
     "\n",
-    "for text_recognition_model in listdir(f\"{download_folder}/public/{recognition_model_name}/{precision}\"):\n",
-    "    copy(src=f\"{download_folder}/public/{recognition_model_name}/{precision}/{text_recognition_model}\", dst=model_folder)"
+    "To make it easier to work with the models, we copy the models from the Open Model Zoo tree to the _model_ subdirectory relative to this notebook. We get the path to the Open Model Zoo model directory from Open Model Zoo's `omz_info_dumper` tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15e2e52b-2363-48d2-97c9-9b04b636f9f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models_info_output = %sx omz_info_dumper --name $detection_model,$recognition_model\n",
+    "detection_model_info, recognition_model_info = json.loads(models_info_output.get_nlstr())\n",
+    "\n",
+    "for model_info in (detection_model_info, recognition_model_info):\n",
+    "    omz_dir = Path(model_info[\"subdirectory\"])\n",
+    "    omz_model_dir = base_model_dir / omz_dir / precision \n",
+    "    for model_file in omz_model_dir.iterdir():\n",
+    "        try:\n",
+    "            shutil.copyfile(model_file, model_dir / model_file.name)\n",
+    "        except FileExistsError:\n",
+    "            pass\n",
+    "\n",
+    "detection_model_path = (model_dir / detection_model).with_suffix(\".xml\")\n",
+    "recognition_model_path = (model_dir / recognition_model).with_suffix(\".xml\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "b12579c5",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "## Load the network"
+    "## Object Detection\n",
+    "\n",
+    "Load the detection model, load an image, do inference and get the detection inference result.\n",
+    "\n",
+    "### Load Detection Model"
    ]
   },
   {
@@ -155,20 +207,22 @@
    },
    "outputs": [],
    "source": [
-    "net = ie.read_network(\n",
-    "    model=f\"{model_folder}/{detection_model_name}.xml\"\n",
+    "detection_net = ie.read_network(\n",
+    "    model=detection_model_path, weights=detection_model_path.with_suffix(\".bin\")\n",
     ")\n",
-    "exec_net = ie.load_network(net, \"CPU\")\n",
+    "detection_exec_net = ie.load_network(detection_net, \"CPU\")\n",
     "\n",
-    "input_layer_ir = next(iter(exec_net.input_info))"
+    "detection_input_layer = next(iter(detection_exec_net.input_info))"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "9729bafe",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "## Load an Image"
+    "### Load an Image"
    ]
   },
   {
@@ -176,45 +230,28 @@
    "execution_count": null,
    "id": "66495015",
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
-    "# Create data folder\n",
-    "makedirs(data_folder, exist_ok=True)\n",
+    "# image_file can point to a URL or local image\n",
+    "image_file = \"https://github.com/openvinotoolkit/openvino_notebooks/raw/main/notebooks/004-hello-detection/data/intel_rnb.jpg\"\n",
     "\n",
-    "# Download image\n",
-    "image_link = 'https://github.com/openvinotoolkit/openvino_notebooks/raw/main/notebooks/004-hello-detection/data/intel_rnb.jpg'\n",
-    "r = get(image_link, stream=True)\n",
-    "if r.status_code == 200:\n",
-    "    r.raw.decode_content = True\n",
-    "    filename = image_link.split('/')[-1]\n",
-    "    with open(f\"{data_folder}/{filename}\",'wb') as f:\n",
-    "        copyfileobj(r.raw, f)\n",
-    "else:\n",
-    "    raise FileNotFoundError(f'Unable to download image from link {image_link}, Status code: {r.status_code}')\n",
-    "\n",
-    "# Text detection models expects image in BGR format\n",
-    "image = cv2.imread(\"data/intel_rnb.jpg\")\n",
+    "image = load_image(image_file)\n",
     "\n",
     "# N,C,H,W = batch size, number of channels, height, width\n",
-    "N, C, H, W = net.input_info[input_layer_ir].tensor_desc.dims\n",
+    "N, C, H, W = detection_net.input_info[detection_input_layer].tensor_desc.dims\n",
     "\n",
     "# Resize image to meet network expected input sizes\n",
     "resized_image = cv2.resize(image, (W, H))\n",
     "\n",
     "# Reshape to network input shape\n",
-    "input_image = np.expand_dims(\n",
-    "    resized_image.transpose(2, 0, 1), 0\n",
-    ")\n",
+    "input_image = np.expand_dims(resized_image.transpose(2, 0, 1), 0)\n",
     "\n",
-    "plt.imshow(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))"
+    "plt.imshow(cv2.cvtColor(image, cv2.COLOR_BGR2RGB));"
    ]
   },
   {
@@ -222,7 +259,7 @@
    "id": "7c2ed960",
    "metadata": {},
    "source": [
-    "## Get boxes\n",
+    "### Do Inference\n",
     "\n",
     "It detects texts in images and returns blob of data in shape of [100, 5]. For each detection description has format [x_min, y_min, x_max, y_max, conf]."
    ]
@@ -242,13 +279,21 @@
    },
    "outputs": [],
    "source": [
-    "result = exec_net.infer(inputs={input_layer_ir: input_image})\n",
+    "result = detection_exec_net.infer(inputs={detection_input_layer: input_image})\n",
     "\n",
     "# Extract list of boxes from results\n",
-    "boxes = result['boxes']\n",
+    "boxes = result[\"boxes\"]\n",
     "\n",
     "# Remove zero only boxes\n",
-    "boxes = boxes[~np.all(boxes==0, axis=1)]"
+    "boxes = boxes[~np.all(boxes == 0, axis=1)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6191cad8-35b2-4cdb-a00c-1f3d7a01754d",
+   "metadata": {},
+   "source": [
+    "### Get Detection Result"
    ]
   },
   {
@@ -267,7 +312,11 @@
    "outputs": [],
    "source": [
     "def multiply_by_ratio(ratio_x, ratio_y, box):\n",
-    "    return [max(shape * ratio_y, 10) if idx % 2 else shape * ratio_x for idx, shape in enumerate(box[:-1])]\n",
+    "    return [\n",
+    "        max(shape * ratio_y, 10) if idx % 2 else shape * ratio_x\n",
+    "        for idx, shape in enumerate(box[:-1])\n",
+    "    ]\n",
+    "\n",
     "\n",
     "def run_preprocesing_on_crop(crop, net_shape):\n",
     "    temp_img = cv2.resize(crop, net_shape)\n",
@@ -275,60 +324,68 @@
     "    return temp_img\n",
     "\n",
     "\n",
-    "def convert_result_to_image(bgr_image, resized_image, boxes, threshold=0.3, conf_labels=True): \n",
+    "def convert_result_to_image(bgr_image, resized_image, boxes, threshold=0.3, conf_labels=True):\n",
     "    # Define colors for boxes and descriptions\n",
-    "    colors = {'red': (255, 0, 0), 'green': (0, 255, 0), 'white': (255, 255, 255)} \n",
+    "    colors = {\"red\": (255, 0, 0), \"green\": (0, 255, 0), \"white\": (255, 255, 255)}\n",
     "\n",
     "    # Fetch image shapes to calculate ratio\n",
     "    (real_y, real_x), (resized_y, resized_x) = image.shape[:2], resized_image.shape[:2]\n",
-    "    ratio_x, ratio_y = real_x/resized_x, real_y/resized_y\n",
+    "    ratio_x, ratio_y = real_x / resized_x, real_y / resized_y\n",
     "\n",
     "    # Convert base image from bgr to rgb format\n",
-    "    rgb_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2RGB) \n",
+    "    rgb_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2RGB)\n",
     "\n",
     "    # Iterate through non-zero boxes\n",
-    "    for box, annotation in boxes: \n",
+    "    for box, annotation in boxes:\n",
     "        # Pick confidence factor from last place in array\n",
     "        conf = box[-1]\n",
-    "        if conf > threshold: \n",
+    "        if conf > threshold:\n",
     "            # Convert float to int and multiply position of each box by x and y ratio\n",
-    "            (x_min, y_min, x_max, y_max) = map(int, multiply_by_ratio(ratio_x, ratio_y, box)) \n",
+    "            (x_min, y_min, x_max, y_max) = map(int, multiply_by_ratio(ratio_x, ratio_y, box))\n",
     "\n",
-    "            # Draw box based on position, parameters in rectangle function are: image, start_point, end_point, color, thickness \n",
-    "            cv2.rectangle( \n",
-    "                rgb_image, \n",
-    "                (x_min, y_min), \n",
-    "                (x_max, y_max), \n",
-    "                colors['green'], \n",
-    "                3\n",
-    "            ) \n",
+    "            # Draw box based on position, parameters in rectangle function are: image, start_point, end_point, color, thickness\n",
+    "            cv2.rectangle(rgb_image, (x_min, y_min), (x_max, y_max), colors[\"green\"], 3)\n",
     "\n",
-    "            # Add text to image based on position and confidence, parameters in putText function are: image, text, bottomleft_corner_textfield, font, font_scale, color, thickness, line_type \n",
+    "            # Add text to image based on position and confidence, parameters in putText function are: image, text, bottomleft_corner_textfield, font, font_scale, color, thickness, line_type\n",
     "            if conf_labels:\n",
     "                # Create background box based on annotation length\n",
-    "                (text_w, text_h), _ = cv2.getTextSize(f\"{annotation}\", cv2.FONT_HERSHEY_TRIPLEX, 0.8, 1)\n",
+    "                (text_w, text_h), _ = cv2.getTextSize(\n",
+    "                    f\"{annotation}\", cv2.FONT_HERSHEY_TRIPLEX, 0.8, 1\n",
+    "                )\n",
     "                image_copy = rgb_image.copy()\n",
-    "                cv2.rectangle( \n",
-    "                    image_copy, \n",
-    "                    (x_min, y_min - text_h - 10), \n",
-    "                    (x_min + text_w, y_min - 10), \n",
-    "                    colors['white'], \n",
-    "                    -1\n",
+    "                cv2.rectangle(\n",
+    "                    image_copy,\n",
+    "                    (x_min, y_min - text_h - 10),\n",
+    "                    (x_min + text_w, y_min - 10),\n",
+    "                    colors[\"white\"],\n",
+    "                    -1,\n",
     "                )\n",
     "                # Add weighted image copy with white boxes under text\n",
     "                cv2.addWeighted(image_copy, 0.4, rgb_image, 0.6, 0, rgb_image)\n",
-    "                cv2.putText( \n",
-    "                    rgb_image, \n",
-    "                    f\"{annotation}\", \n",
-    "                    (x_min, y_min - 10), \n",
-    "                    cv2.FONT_HERSHEY_SIMPLEX, \n",
-    "                    0.8, \n",
-    "                    colors['red'], \n",
-    "                    1, \n",
-    "                    cv2.LINE_AA\n",
-    "                ) \n",
-    "            \n",
+    "                cv2.putText(\n",
+    "                    rgb_image,\n",
+    "                    f\"{annotation}\",\n",
+    "                    (x_min, y_min - 10),\n",
+    "                    cv2.FONT_HERSHEY_SIMPLEX,\n",
+    "                    0.8,\n",
+    "                    colors[\"red\"],\n",
+    "                    1,\n",
+    "                    cv2.LINE_AA,\n",
+    "                )\n",
+    "\n",
     "    return rgb_image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe18dbe3-fcce-40ca-bff7-57d11885efbb",
+   "metadata": {},
+   "source": [
+    "## Text Recogntion\n",
+    "\n",
+    "Load the text recognition model and do inference on the detected boxes from the detection model.\n",
+    "\n",
+    "### Load Text Recognition Model"
    ]
   },
   {
@@ -339,13 +396,24 @@
    "outputs": [],
    "source": [
     "recognition_net = ie.read_network(\n",
-    "    model=f\"{model_folder}/{recognition_model_name}.xml\"\n",
+    "    model=recognition_model_path, weights=recognition_model_path.with_suffix(\".bin\")\n",
     ")\n",
     "\n",
-    "exec_recognition_net = ie.load_network(recognition_net, \"CPU\")\n",
+    "recognition_exec_net = ie.load_network(recognition_net, \"CPU\")\n",
     "\n",
-    "recognition_output_layer = next(iter(exec_recognition_net.outputs))\n",
-    "recognition_input_layer = next(iter(exec_recognition_net.input_info))\n"
+    "recognition_output_layer = next(iter(recognition_exec_net.outputs))\n",
+    "recognition_input_layer = next(iter(recognition_exec_net.input_info))\n",
+    "\n",
+    "# Get height and width of input layer\n",
+    "_, _, H, W = recognition_net.input_info[recognition_input_layer].tensor_desc.dims"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f70b8d2-cd1f-4554-ad66-46961336501f",
+   "metadata": {},
+   "source": [
+    "### Do Inference"
    ]
   },
   {
@@ -355,12 +423,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get height and width of input layer\n",
-    "_, _, H, W = recognition_net.input_info[recognition_input_layer].tensor_desc.dims\n",
-    "\n",
     "# Calculate scale for image resizing\n",
     "(real_y, real_x), (resized_y, resized_x) = image.shape[:2], resized_image.shape[:2]\n",
-    "ratio_x, ratio_y = real_x/resized_x, real_y/resized_y\n",
+    "ratio_x, ratio_y = real_x / resized_x, real_y / resized_y\n",
     "\n",
     "# Convert image to grayscale for text recognition model\n",
     "grayscale_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)\n",
@@ -370,19 +435,20 @@
     "\n",
     "# Prepare empty list for annotations\n",
     "annotations = list()\n",
-    "\n",
+    "cropped_images = list()\n",
+    "# fig, ax = plt.subplots(len(boxes), 1, figsize=(5,15), sharex=True, sharey=True)\n",
     "# For each crop, based on boxes given by detection model we want to get annotations\n",
-    "for crop in boxes:\n",
+    "for i, crop in enumerate(boxes):\n",
     "    # Get coordinates on corners of crop\n",
     "    (x_min, y_min, x_max, y_max) = map(int, multiply_by_ratio(ratio_x, ratio_y, crop))\n",
     "    image_crop = run_preprocesing_on_crop(grayscale_image[y_min:y_max, x_min:x_max], (W, H))\n",
-    "    \n",
+    "\n",
     "    # Run inference with recognition model\n",
-    "    recognition_result = exec_recognition_net.infer(inputs={recognition_input_layer: image_crop})\n",
-    "    \n",
+    "    recognition_result = recognition_exec_net.infer(inputs={recognition_input_layer: image_crop})\n",
+    "\n",
     "    # Squeeze output to remove unnececery dimension\n",
     "    recognition_results_test = np.squeeze(recognition_result[recognition_output_layer])\n",
-    "    \n",
+    "\n",
     "    # Read annotation based on probabilities from output layer\n",
     "    annotation = list()\n",
     "    for letter in recognition_results_test:\n",
@@ -392,9 +458,25 @@
     "        if parsed_letter == letters[0]:\n",
     "            break\n",
     "        annotation.append(parsed_letter)\n",
-    "    annotations.append(''.join(annotation))\n",
+    "    annotations.append(\"\".join(annotation))\n",
+    "    cropped_image = Image.fromarray(image[y_min:y_max, x_min:x_max])\n",
+    "    cropped_images.append(cropped_image)\n",
     "\n",
-    "boxes_with_annotations = zip(boxes, annotations)\n"
+    "boxes_with_annotations = list(zip(boxes, annotations))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec75936e-63bf-49b4-9bd9-790f3bc396c9",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Show Results\n",
+    "\n",
+    "### Show detected boxes and OCR result on image\n",
+    "\n",
+    "Visualize the result by drawing boxes around recognized text and showing the OCR result from the text recognition model"
    ]
   },
   {
@@ -404,7 +486,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.imshow(convert_result_to_image(image, resized_image, boxes_with_annotations, conf_labels=True))\n"
+    "plt.figure(figsize=(12, 12))\n",
+    "plt.imshow(convert_result_to_image(image, resized_image, boxes_with_annotations, conf_labels=True));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd96468c-30fc-4679-8984-a530dff453c5",
+   "metadata": {},
+   "source": [
+    "### Show OCR result per detected box\n",
+    "\n",
+    "Depending on the image, the OCR result may not be readable in the image with boxes as displayed in the cell above. In the next cell, we show the extracted boxes, and the OCR result per box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b756c02c-51f9-47ab-9808-ee2a1443860d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for cropped_image, annotation in zip(cropped_images, annotations):\n",
+    "    display(cropped_image, Markdown(\"\".join(annotation)))"
    ]
   },
   {
@@ -412,7 +516,7 @@
    "id": "18e3dcbe",
    "metadata": {},
    "source": [
-    "## Print annotation in text format\n",
+    "### Print annotation in text format\n",
     "\n",
     "Print annotations for detected text based on their position in the input image starting from the upper left corner.\n"
    ]
@@ -421,10 +525,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "59ea77ce",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "[annotation for _, annotation in sorted(zip(boxes, annotations), key=lambda x: x[0][0]**2 + x[0][1]**2)]"
+    "[\n",
+    "    annotation\n",
+    "    for _, annotation in sorted(zip(boxes, annotations), key=lambda x: x[0][0] ** 2 + x[0][1] ** 2)\n",
+    "]"
    ]
   }
  ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pytube
 requests
 tqdm
 openvino-extensions
+yaspin
 
 # ONNX notebook requirements
 geffnet==0.9.8


### PR DESCRIPTION
- Add spinner to show download progress (with yaspin)
- Change OMZ download directories
- Add visualization of OCR on extracted boxes
- Add ~/open_model_zoo_cache to Github Actions CI and add 208 back to CI
- Use load_image to load image from url or file
- Add E703 (semicolon at end of line) to nbqa exclude (semicolon prevents displaying useless return values)

Closes #234 and addresses issues mentioned in #215 

OMZ models are downloaded to standard directories ~/open_model_zoo_models with cache dir ~/open_model_zoo_cache to allow users to use Open Model Zoo's `--all` or `--list` command to download several models at once when they have fast internet and then run the notebooks that use this later. We could explain this in the README/start of the notebooks that use OMZ models. 

To facilitate downloading the model from the Jupyter interface I copy the model in the model directory. It seems better to have file redudancy than download redundancy. I tried to use `os.link` instead of copy. That worked great locally, but gave an error in the CI because on Windows a hard link cannot span different devices. 

Screenshot of added output (below original output)
![fe07e47ffaa9d899d6b2568dc2721293](https://user-images.githubusercontent.com/77325899/135769317-f1b3b5ac-817e-42f7-9daf-e7661443b572.png)
