### PR TITLE
Run Docker tests on PR that changes/adds notebooks or python code

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,8 @@ on:
       - "Dockerfile"
       - ".docker/**"
       - ".github/workflows/docker.yml"
+      - 'notebooks/**.ipynb'
+      - 'notebooks/**.py'
 jobs:
   build:
     strategy:


### PR DESCRIPTION
This used to be useless because the Docker image pulled the notebooks from main, but with the new Docker image we can test the notebooks in the Docker image on PR again and immediately see if a notebook fails there.