### PR TITLE
Corrected 302 notebook: QAT accuracy is better than PTQ one

### DIFF
--- a/notebooks/302-pytorch-quantization-aware-training/302-pytorch-quantization-aware-training.ipynb
+++ b/notebooks/302-pytorch-quantization-aware-training/302-pytorch-quantization-aware-training.ipynb
@@ -500,7 +500,7 @@
     "    #\n",
     "    checkpoint = torch.load(str(fp32_pth_path), map_location=\"cpu\")\n",
     "    model.load_state_dict(checkpoint[\"state_dict\"], strict=True)\n",
-    "    best_acc1 = acc1 = checkpoint[\"acc1\"]\n",
+    "    best_acc1 = checkpoint[\"acc1\"]\n",
     "else:\n",
     "    # Training loop\n",
     "    for epoch in range(0, epochs):\n",


### PR DESCRIPTION
QAT (quantization aware training) method is supposed to produce a more accurate model then in PTQ (post training quantization)one , but notebook shows and opposite results from time to time. 

It is confusing for the user, this PR fix such behaviour.

![image](https://user-images.githubusercontent.com/4014476/136935593-15e0f9d9-4485-4824-aa5c-a15b37164506.png)
![image](https://user-images.githubusercontent.com/4014476/136935602-bbcf0566-2970-4d8b-8b94-b6ff373cfbb7.png)
![image](https://user-images.githubusercontent.com/4014476/136935609-64b2ead2-445c-4afb-bfc3-c62596972fff.png)
![image](https://user-images.githubusercontent.com/4014476/136935623-9d8187c3-e9a8-4436-8481-dc0cdd0a9db2.png)
