### PR TITLE
Run full notebooks in export to markdown/HTML/rst

### DIFF
--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -50,11 +50,6 @@ jobs:
       with:
         name: pip-freeze
         path: pip-freeze.txt
-    - name: Modify Notebooks
-      # Change settings in slower notebooks to speed up notebook execution
-      run: |
-        sed -i 's/NUM_FRAMES = 100/NUM_FRAMES = 5/g' notebooks/202-vision-superresolution/202-vision-superresolution-video.ipynb
-        sed -i 's/epochs = 15/epochs = 2/g' notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino.ipynb
     - name: convert_notebooks
       run: bash .ci/convert_notebooks.sh
     - name: Save HTML files


### PR DESCRIPTION
So far, the markdown/rst/HTML files were generated to be able to quickly show an executed notebook, and to allow C++ engineers to translate the tutorials to C++. The convert_notebooks CI job modified the notebooks to make them run quicker (fewer epochs, fewer minutes of video analyzed, for selected notebooks). For documentation integration, the full notebooks should be executed, so this PR removes these modifications.