### PR TITLE
104 rst table layout fix

### DIFF
--- a/notebooks/104-model-tools/104-model-tools.ipynb
+++ b/notebooks/104-model-tools/104-model-tools.ipynb
@@ -6,9 +6,9 @@
    "metadata": {},
    "source": [
     "# Working with Open Model Zoo Models\n",
-    "This tutorial shows how to download a model from the [Open Model Zoo](https://github.com/openvinotoolkit/open_model_zoo), convert to OpenVINO IR format, show information about the model, and benchmark the model.\n",
+    "This tutorial shows how to download a model from the [Open Model Zoo](https://github.com/openvinotoolkit/open_model_zoo), convert it to OpenVINO's IR format, show information about the model, and benchmark the model.\n",
     "\n",
-    "## Open Model Zoo Tools"
+    "## OpenVINO and Open Model Zoo Tools"
    ]
   },
   {
@@ -20,14 +20,14 @@
     ]
    },
    "source": [
-    "The Open Model Zoo tools are listed in the table below. \n",
+    "The OpenVINO and Open Model Zoo tools are listed in the table below.\n",
     "\n",
-    "| Tool             | Command           | Description                                                                       |\n",
-    "|------------------|-------------------|-----------------------------------------------------------------------------------|\n",
-    "| Model Downloader | `omz_downloader`  | Download models from Open Model Zoo                                               |\n",
-    "| Model Converter  | `omz_converter`   | Convert Open Model Zoo models that are not in OpenVINO's IR format to that format |\n",
-    "| Info Dumper      | `omz_info_dumper` | Print information about Open Model Zoo models                                     |\n",
-    "| Benchmark Tool   | `benchmark_app`   | Benchmark model performance by computing inference time                           |"
+    "| Tool             | Command  Name         | Description                                             |\n",
+    "|------------------|-----------------------|---------------------------------------------------------|\n",
+    "| Model Downloader | `omz_downloader`      | Download models from Open Model Zoo                     |\n",
+    "| Model Converter  | `omz_converter`       | Convert Open Model Zoo models to OpenVINO's IR format   |\n",
+    "| Info Dumper      | `omz_info_dumper`     | Print information about Open Model Zoo models           |\n",
+    "| Benchmark Tool   | `benchmark_app`       | Benchmark model performance by computing inference time |"
    ]
   },
   {
@@ -460,7 +460,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Rename Command to Command Name in table with OMZ and OpenVINO tools to fix issue with rst formatting in docs
Not the best fix, but it would be nice if this works.I validated locally that the generated rst does not have backticks on lines by themselves anymore. 

Also rename OMZ tools to OpenVINO and OMZ tools. Feel free to rename, I just did not want to imply that benchmark app is an OMZ tool. 

![image](https://user-images.githubusercontent.com/77325899/137337429-40527acc-a252-42be-931e-956f19b30357.png)
