### PR TITLE
Remove backticks in 104

### DIFF
--- a/notebooks/104-model-tools/104-model-tools.ipynb
+++ b/notebooks/104-model-tools/104-model-tools.ipynb
@@ -23,7 +23,7 @@
     "The OpenVINO and Open Model Zoo tools are listed in the table below.\n",
     "\n",
     "| Tool             | Command             | Description                                             |\n",
-    "|------------------|---------------------|---------------------------------------------------------|\n",
+    "|:-----------------|:--------------------|:--------------------------------------------------------|\n",
     "| Model Downloader | omz_downloader      | Download models from Open Model Zoo                     |\n",
     "| Model Converter  | omz_converter       | Convert Open Model Zoo models to OpenVINO's IR format   |\n",
     "| Info Dumper      | omz_info_dumper     | Print information about Open Model Zoo models           |\n",


### PR DESCRIPTION
Commands between backticks in tools table are not rendered correctly in exported rst files and documentation based on them (`omz_downloader` becomes `omz_downloa der`).
Remove backticks temporarily to show correct command names in documentation. We should find a better fix, but for now this will hopefully at least show the command names in the rendered table.