### PR TITLE
Change link to onnx notebook in 205

### DIFF
--- a/notebooks/205-vision-background-removal/205-vision-background-removal.ipynb
+++ b/notebooks/205-vision-background-removal/205-vision-background-removal.ipynb
@@ -21,7 +21,7 @@
     ]
    },
    "source": [
-    "The PyTorch U$^2$-Net model is converted to ONNX and loaded with OpenVINO. The model source is https://github.com/xuebinqin/U-2-Net. For a more detailed overview of loading PyTorch models in OpenVINO, including how to load an ONNX model in OpenVINO directly, without converting to IR format, check out the [PyTorch/ONNX](../102-pytorch-onnx-to-openvino) notebook."
+    "The PyTorch U$^2$-Net model is converted to ONNX and loaded with OpenVINO. The model source is https://github.com/xuebinqin/U-2-Net. For a more detailed overview of loading PyTorch models in OpenVINO, including how to load an ONNX model in OpenVINO directly, without converting to IR format, check out the [PyTorch/ONNX](../102-pytorch-onnx-to-openvino/102-pytorch-onnx-to-openvino.ipynb) notebook."
    ]
   },
   {


### PR DESCRIPTION
The link to the PyTorch/ONNX notebook went to the directory, this PR changes it to the file, making it also work in the documentation.