### PR TITLE
Fix live inference in jupyter notebook (instead of lab)

### DIFF
--- a/notebooks/210-ct-scan-live-inference/210-ct-scan-live-inference.ipynb
+++ b/notebooks/210-ct-scan-live-inference/210-ct-scan-live-inference.ipynb
@@ -68,6 +68,7 @@
     "# case_00XXX where XXX is between 000 and 299, with data prepared according to #TODO\n",
     "basedir = \"kits19_frames\"\n",
     "# The CT scan case number. For example: 16 for data from the case_00016 directory\n",
+    "# Currently only 16 is supported\n",
     "case = 16\n",
     "# The directory that contains the IR model files. Should contain unet44.xml and bin\n",
     "# and quantized_unet44.xml and bin.\n",
@@ -258,8 +259,8 @@
     "        raise ValueError(f\"A GPU device is not available. Available devices are: {ie.available_devices}\")\n",
     "    else:\n",
     "        benchmark_command = f\"benchmark_app -m {model_path} -d {device} -t {seconds} -api {api} -b {batch} -cdir model_cache\"\n",
-    "        display(Markdown(f\"**Benchmark {model_path.name} with {device} for {seconds} seconds with {api} inference**\"))\n",
-    "        display(Markdown(f\"Benchmark command: `{benchmark_command}`\"))\n",
+    "        display(Markdown(f\"**Benchmark {model_path.name} with {device} for {seconds} seconds with {api} inference**\"));\n",
+    "        display(Markdown(f\"Benchmark command: `{benchmark_command}`\"));\n",
     "\n",
     "        benchmark_output = %sx $benchmark_command\n",
     "        benchmark_result = [line for line in benchmark_output\n",
@@ -296,7 +297,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "benchmark_model(model_xml=compressed_model_path, device=\"CPU\", seconds=15)"
+    "benchmark_model(model_xml=compressed_model_path, device=device, seconds=15)"
    ]
   },
   {
@@ -348,7 +349,7 @@
     "    :param model: Model instance for inference\n",
     "    :param device: Name of device to perform inference on. For example: \"CPU\"\n",
     "    \"\"\"\n",
-    "    display_handle = display(display_id=True)\n",
+    "    display_handle = display(\"\", display_id=True)\n",
     "    input_layer = next(iter(model.net.input_info))\n",
     "\n",
     "    # Create asynchronous pipeline and print time it takes to load the model\n",
@@ -447,16 +448,9 @@
    "outputs": [],
    "source": [
     "# Possible options for device include \"CPU\", \"GPU\", \"AUTO\", \"MULTI\"\n",
-    "device = \"CPU\"\n",
+    "device = \"MULTI:CPU,GPU\" if \"GPU\" in ie.available_devices else \"CPU\"\n",
     "do_inference(imagelist=images, model=segmentation_model, device=device)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fix live inference in classic notebook interface
Add `;` after markdown cells to prevent additional output in notebook interface
Set benchmark_app to do inference on `device` instead of hardcoded CPU in one and device in other cell
