### PR TITLE
Corrections to remove confusion in 302 notebook

### DIFF
--- a/notebooks/302-pytorch-quantization-aware-training/302-pytorch-quantization-aware-training.ipynb
+++ b/notebooks/302-pytorch-quantization-aware-training/302-pytorch-quantization-aware-training.ipynb
@@ -122,11 +122,13 @@
     "\n",
     "MODEL_DIR = Path(\"model\")\n",
     "OUTPUT_DIR = Path(\"output\")\n",
+    "DATA_DIR = Path(\"data\")\n",
     "BASE_MODEL_NAME = \"resnet18\"\n",
     "image_size = 64\n",
     "\n",
     "OUTPUT_DIR.mkdir(exist_ok=True)\n",
     "MODEL_DIR.mkdir(exist_ok=True)\n",
+    "DATA_DIR.mkdir(exist_ok=True)\n",
     "\n",
     "# Paths where PyTorch, ONNX and OpenVINO IR models will be stored\n",
     "fp32_pth_path = Path(MODEL_DIR / (BASE_MODEL_NAME + \"_fp32\")).with_suffix(\".pth\")\n",
@@ -172,22 +174,22 @@
    "outputs": [],
    "source": [
     "def download_tiny_imagenet_200(\n",
-    "    output_dir,\n",
+    "    data_dir,\n",
     "    url=\"http://cs231n.stanford.edu/tiny-imagenet-200.zip\",\n",
     "    tarname=\"tiny-imagenet-200.zip\",\n",
     "):\n",
-    "    output_dir.mkdir(exist_ok=True)\n",
-    "    archive_path = output_dir / tarname\n",
+    "    data_dir.mkdir(exist_ok=True)\n",
+    "    archive_path = data_dir / tarname\n",
     "    urlretrieve(url, archive_path)\n",
     "    zip_ref = zipfile.ZipFile(archive_path, \"r\")\n",
-    "    zip_ref.extractall(path=output_dir)\n",
+    "    zip_ref.extractall(path=data_dir)\n",
     "    zip_ref.close()\n",
-    "    print(f\"Successfully downloaded and extracted dataset to: {output_dir}\")\n",
+    "    print(f\"Successfully downloaded and extracted dataset to: {data_dir}\")\n",
     "\n",
     "\n",
-    "DATASET_DIR = OUTPUT_DIR / \"tiny-imagenet-200\"\n",
+    "DATASET_DIR = DATA_DIR / \"tiny-imagenet-200\"\n",
     "if not DATASET_DIR.exists():\n",
-    "    download_tiny_imagenet_200(OUTPUT_DIR)"
+    "    download_tiny_imagenet_200(DATA_DIR)"
    ]
   },
   {
@@ -405,18 +407,8 @@
     }
    },
    "source": [
-    "### Run training pipeline\n",
-    "Tune floating-point ResNet-18 on Tiny-ImageNet-200 to obtain a pre-trained model for quantization."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "118rlV22_PB5"
-   },
-   "source": [
-    "> **NOTE** The model is not tuned till the final accuracy. For the sake of simplicity of the tutorial, we tune for 4 epoch only and take the last model state for quantization.\n",
-    "\n"
+    "### Get a pretrained FP32 model\n",
+    "А pre-trained floating-point model is a prerequisite for quantization. It can be obtained by tuning from scratch  with the code below. However, usually it takes a lot of time. Therefore, we had already run this code and received the good enough weights after 4 epochs (for the sake of simplicity don't tune until the best accuracy). By default, this notebook just loads this weights without launching training. To tune model from scratch set `pretrained=False`.\n"
    ]
   },
   {


### PR DESCRIPTION
Download dataset to data directory. It addresses the feedback:
> The dataset is downloaded in output/ folder which is a little bit counter-intuitive since we put the dataset in dataset/ or data/ generally. Output/ is usually for the results

Corrected text about pre-training model. Explicitly say about loading a pre-trained weight instead of running tuning.