### PR TITLE
Speed up CI tests for 305

### DIFF
--- a/notebooks/305-tensorflow-quantization-aware-training/305-tensorflow-quantization-aware-training.ipynb
+++ b/notebooks/305-tensorflow-quantization-aware-training/305-tensorflow-quantization-aware-training.ipynb
@@ -382,7 +382,11 @@
    "execution_count": null,
    "id": "b4047d88",
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "tags": [],
+    "test_replace": {
+     "fit(train_dataset,": "fit(validation_dataset,"
+    }
    },
    "outputs": [],
    "source": [


### PR DESCRIPTION
Training for this notebook can take over 15 minutes in the CI. This PR should make it much faster by patching the notebook in the CI to use the validation set for training in the CI test.