### PR TITLE
Fix links to benchmark tool documentation

### DIFF
--- a/notebooks/101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb
+++ b/notebooks/101-tensorflow-to-openvino/101-tensorflow-to-openvino.ipynb
@@ -216,7 +216,7 @@
    "source": [
     "## Timing\n",
     "\n",
-    "Measure the time it takes to do inference on thousand images. This gives an indication of performance. For more accurate benchmarking, use the [OpenVINO benchmark tool](https://github.com/openvinotoolkit/openvino/tree/master/inference-engine/tools/benchmark_tool). Note that many optimizations are possible to improve the performance. "
+    "Measure the time it takes to do inference on thousand images. This gives an indication of performance. For more accurate benchmarking, use the [OpenVINO benchmark tool](https://docs.openvino.ai/latest/openvino_inference_engine_tools_benchmark_tool_README.html). Note that many optimizations are possible to improve the performance. "
    ]
   },
   {

--- a/notebooks/103-paddle-onnx-to-openvino/103-paddle-onnx-to-openvino-classification.ipynb
+++ b/notebooks/103-paddle-onnx-to-openvino/103-paddle-onnx-to-openvino-classification.ipynb
@@ -318,7 +318,7 @@
    "source": [
     "## Timing and Comparison\n",
     "\n",
-    "Measure the time it takes to do inference on fifty images and compare the result. The timing information gives an indication of performance. For a fair comparison, we include the time it takes to process the image. For more accurate benchmarking, use the [OpenVINO benchmark tool](https://github.com/openvinotoolkit/openvino/tree/master/inference-engine/tools/benchmark_tool). Note that many optimizations are possible to improve the performance."
+    "Measure the time it takes to do inference on fifty images and compare the result. The timing information gives an indication of performance. For a fair comparison, we include the time it takes to process the image. For more accurate benchmarking, use the [OpenVINO benchmark tool](https://docs.openvino.ai/latest/openvino_inference_engine_tools_benchmark_tool_README.html). Note that many optimizations are possible to improve the performance."
    ]
   },
   {

--- a/notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino-pot.ipynb
+++ b/notebooks/301-tensorflow-training-openvino/301-tensorflow-training-openvino-pot.ipynb
@@ -435,9 +435,9 @@
    "source": [
     "## Compare Inference Speed\n",
     "\n",
-    "Measure inference speed with the [OpenVINO Benchmark App](https://github.com/openvinotoolkit/openvino/tree/master/inference-engine/tools/benchmark_tool). \n",
+    "Measure inference speed with the [OpenVINO Benchmark App](https://docs.openvino.ai/latest/openvino_inference_engine_tools_benchmark_tool_README.html). \n",
     "\n",
-    "Benchmark App is a command line tool that measures raw inference performance for a specified OpenVINO IR model. Run `benchmark_app --help` to see a list of available parameters. By default, Benchmark App tests the performance of the model specified with the `-m` parameter with asynchronous inference on CPU, for one minute. Use the `-d` parameter to test performance on a different device, for example an Intel integrated Graphics (iGPU), and `-t` to set the number of seconds to run inference. See the [documentation](https://github.com/openvinotoolkit/openvino/tree/master/inference-engine/tools/benchmark_tool) for more information. \n",
+    "Benchmark App is a command line tool that measures raw inference performance for a specified OpenVINO IR model. Run `benchmark_app --help` to see a list of available parameters. By default, Benchmark App tests the performance of the model specified with the `-m` parameter with asynchronous inference on CPU, for one minute. Use the `-d` parameter to test performance on a different device, for example an Intel integrated Graphics (iGPU), and `-t` to set the number of seconds to run inference. See the [documentation](https://docs.openvino.ai/latest/openvino_inference_engine_tools_benchmark_tool_README.html) for more information. \n",
     "\n",
     "In this tutorial, we use a wrapper function from [Notebook Utils](https://github.com/openvinotoolkit/openvino_notebooks/blob/main/notebooks/utils/notebook_utils.ipynb). It prints the `benchmark_app` command with the chosen parameters.\n",
     "\n",


### PR DESCRIPTION
Previous link was to github and returns a 404 error now. Replaced with links to https://docs.openvino.ai/latest/openvino_inference_engine_tools_benchmark_tool_README.html