### PR TITLE
Disable CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,15 +5,6 @@ name: "CodeQL"
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
-    paths-ignore:
-      - '**.md'
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
-    paths-ignore:
-      - '**.md'
   schedule:
     - cron: '28 23 * * 0'
 


### PR DESCRIPTION
Temporarily disable CodeQL on Pull Requests because it currently fails with an unclear error. 
Keep enabled for manual and scheduled runs. 