### PR TITLE
CI speedup and minor updates to 112 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Tutorials that explain how to optimize and quantize models with OpenVINO tools.
 | [105-language-quantize-bert](notebooks/105-language-quantize-bert/) | Optimize and quantize a pre-trained BERT model ||
 | [110-ct-segmentation-quantize](notebooks/110-ct-segmentation-quantize/)<br> | Quantize a kidney segmentation model and show live inference | |
 | [111-detection-quantization](notebooks/111-detection-quantization/)<br>[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openvinotoolkit/openvino_notebooks/HEAD?filepath=notebooks%2F111-detection-quantization%2F111-detection-quantization.ipynb) | Quantize an object detection model | |
-| [112-pytorch-post-training-quantization-nncf](112-pytorch-post-training-quantization-nncf) | Use Neural Network Compression Framework (NNCF) to quantize PyTorch model in post-training mode (without model fine-tuning)| |
+| [112-pytorch-post-training-quantization-nncf](notebooks/112-pytorch-post-training-quantization-nncf/) | Use Neural Network Compression Framework (NNCF) to quantize PyTorch model in post-training mode (without model fine-tuning)| |
 
 
 ### Model Demos

--- a/notebooks/112-pytorch-post-training-quantization-nncf/112-pytorch-post-training-quantization-nncf.ipynb
+++ b/notebooks/112-pytorch-post-training-quantization-nncf/112-pytorch-post-training-quantization-nncf.ipynb
@@ -34,7 +34,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [],
+    "test_replace": {
+     "win32": "win32_test_patch"
+    }
+   },
    "outputs": [],
    "source": [
     "# On Windows, this script adds the directory that contains cl.exe to the PATH to enable PyTorch to find the\n",
@@ -510,7 +515,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [],
+    "test_replace": {
+     "train_loader": "val_loader"
+    }
+   },
    "outputs": [],
    "source": [
     "nncf_config = register_default_init_args(nncf_config, train_loader)"
@@ -643,7 +653,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [],
+    "test_replace": {
+     "-t 15": "-t 3"
+    }
+   },
    "outputs": [],
    "source": [
     "def parse_benchmark_output(benchmark_output: str):\n",

--- a/notebooks/112-pytorch-post-training-quantization-nncf/112-pytorch-post-training-quantization-nncf.ipynb
+++ b/notebooks/112-pytorch-post-training-quantization-nncf/112-pytorch-post-training-quantization-nncf.ipynb
@@ -35,10 +35,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": [],
-    "test_replace": {
-     "win32": "win32_test_patch"
-    }
+    "tags": []
    },
    "outputs": [],
    "source": [

--- a/notebooks/112-pytorch-post-training-quantization-nncf/README.md
+++ b/notebooks/112-pytorch-post-training-quantization-nncf/README.md
@@ -1,17 +1,19 @@
-# Optimizing PyTorch models with Neural Network Compression Framework of OpenVINO by 8-bit quantization.
+# Post-Training Quantization of PyTorch models with NNCF
 
-This tutorial demonstrates how to use [NNCF](https://github.com/openvinotoolkit/nncf) 8-bit quantization in post-training mode (without the fine-tuning pipeline) to optimize a 
-[PyTorch](https://pytorch.org/) model for the high-speed inference via [OpenVINO Toolkit](https://docs.openvinotoolkit.org/). 
-For more advanced usage refer to these [examples](https://github.com/openvinotoolkit/nncf/tree/develop/examples).
+This tutorial demonstrates how to use [NNCF](https://github.com/openvinotoolkit/nncf) 8-bit quantization in
+post-training mode (without the fine-tuning pipeline) to optimize a [PyTorch](https://pytorch.org/) model
+for high-speed inference via [OpenVINO Toolkit](https://docs.openvinotoolkit.org/). For more advanced NNCF
+usage refer to these [examples](https://github.com/openvinotoolkit/nncf/tree/develop/examples).
 
-To make downloading and validating fast, we use an already pretrained [ResNet-50](https://arxiv.org/abs/1512.03385) model on the 
-[Tiny ImageNet](http://cs231n.stanford.edu/reports/2015/pdfs/leonyao_final.pdf) dataset.
+To make downloading and validating fast, we use an already pretrained [ResNet-50](https://arxiv.org/abs/1512.03385)
+model on the [Tiny ImageNet](http://cs231n.stanford.edu/reports/2015/pdfs/leonyao_final.pdf) dataset.
 
 It consists of the following steps:
+
 - Evaluate the original model
 - Transform the original FP32 model to INT8
 - Export optimized and original models to ONNX and then to OpenVINO IR
-- Compare perfomance of the obtained FP32 and INT8 models
+- Compare performance of the obtained FP32 and INT8 models
 
 ## Installation Instructions
 


### PR DESCRIPTION
Fix two small typos and change the title to be the same as the notebook title, which is shorter and shows that this does post-training quantization. 
Also added metadata to CI to speed up tests (change train loader to val loader, decrease benchmark time) https://github.com/openvinotoolkit/openvino_notebooks/wiki/Notebooks-Development---CI-Test-Speedup

Diff shows mostly whitespace changes.