### PR TITLE
Fix performance benchmark in 102

### DIFF
--- a/notebooks/102-pytorch-onnx-to-openvino/102-pytorch-onnx-to-openvino.ipynb
+++ b/notebooks/102-pytorch-onnx-to-openvino/102-pytorch-onnx-to-openvino.ipynb
@@ -470,7 +470,7 @@
    "source": [
     "## Performance Comparison\n",
     "\n",
-    "Measure the time it takes to do inference on five images. This gives an indication of performance. For more accurate benchmarking, use the [OpenVINO Benchmark Tool](https://docs.openvinotoolkit.org/latest/openvino_inference_engine_tools_benchmark_tool_README.html). Note that many optimizations are possible to improve the performance. "
+    "Measure the time it takes to do inference on twenty images. This gives an indication of performance. For more accurate benchmarking, use the [OpenVINO Benchmark Tool](https://docs.openvinotoolkit.org/latest/openvino_inference_engine_tools_benchmark_tool_README.html). Note that many optimizations are possible to improve the performance. "
    ]
   },
   {
@@ -480,7 +480,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "num_images = 5\n",
+    "num_images = 20\n",
     "\n",
     "start = time.perf_counter()\n",
     "for _ in range(num_images):\n",
@@ -514,17 +514,9 @@
     ")\n",
     "\n",
     "if \"GPU\" in ie.available_devices:\n",
-    "    exec_net_onnx_gpu = ie.load_network(network=net_ir, device_name=\"GPU\")\n",
-    "    start = time.perf_counter()\n",
-    "    for _ in range(num_images):\n",
-    "        exec_net_onnx_gpu.infer(inputs={input_layer_onnx: input_image})\n",
-    "    end = time.perf_counter()\n",
-    "    time_onnx_gpu = end - start\n",
-    "    print(\n",
-    "        f\"ONNX model in Inference Engine/GPU: {time_onnx_gpu/num_images:.3f} \"\n",
-    "        f\"seconds per image, FPS: {num_images/time_onnx_gpu:.2f}\"\n",
-    "    )\n",
-    "\n",
+    "    print()\n",
+    "    # Setting CACHE_DIR caches the model which enables faster loading on GPU\n",
+    "    ie.set_config({\"CACHE_DIR\": \"model_cache\"}, device_name=\"GPU\")\n",
     "    exec_net_ir_gpu = ie.load_network(network=net_ir, device_name=\"GPU\")\n",
     "    start = time.perf_counter()\n",
     "    for _ in range(num_images):\n",


### PR DESCRIPTION
`exec_net_onnx_gpu` loaded the IR model, not the ONNX model. I removed the ONNX on GPU benchmark because it adds confusion: ONNX on GPU is much slower than IR. The IR model is FP16, so comparing ONNX FP32 with IR FP16 gives the impression that ONNX is slower than IR instead of FP32 being slower than FP16. For a fair comparison we should also export IR to FP32, but that is overkill for this specific notebook. It could be useful to have a generic performance benchmarking notebook that goes into some detail about this.

I also thought it could be useful to add MULTI, but (with this simple method) that was not useful so I did not add that.
![image](https://user-images.githubusercontent.com/77325899/147148014-33d606d7-60a2-4cb7-aebd-433e5279793d.png)
