### PR TITLE
Fix list of Binder notebooks in CI

### DIFF
--- a/.ci/convert_notebooks.sh
+++ b/.ci/convert_notebooks.sh
@@ -10,7 +10,7 @@ mkdir -p $htmldir
 mkdir -p $markdowndir
 
 # List all notebooks that contain binder buttons based on readme
-cat README.md | grep mybinder.org | awk --source '/[0-9]{3}/' | cut -f1 -d] | cut -f2 -d[ > $binderlist
+cat README.md | grep -E ".*mybinder.*[0-9]{3}.*" | cut -f1 -d] | cut -f2 -d[ > $binderlist
 
 git ls-files "*.ipynb" | while read notebook; do
     executed_notebook=${notebook/.ipynb/-with-output.ipynb}


### PR DESCRIPTION
The convert_notebooks script works well in Github Actions CI but not on systems that do not have gawk installed. #374 was an attempt to fix that, but it still fails. This PR removes awk from the command to generate the list of binder files. 

@Debskij FYI.