### PR TITLE
Add concurrency to Github Actions workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '28 23 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CodeQL:
 

--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -17,6 +17,11 @@ on:
     paths:
     - '.github/workflows/convert_notebooks.yml'
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,11 @@ on:
       - ".github/workflows/docker.yml"
       - 'notebooks/**.ipynb'
       - 'notebooks/**.py'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -23,6 +23,10 @@ on:
   schedule:
     - cron:  '30 8 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_nbval:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
When a PR has many updates, a new Github Actions job starts on every commit. This can lead to dozens of runs and clog the CI. This PR adds [concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) to cancel in progress runs on a new commit. 