### PR TITLE
Pin pip to 21.3 to fix PyTorch install issue

### DIFF
--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Cache openvino packages
       if: steps.cachepip.outputs.cache-hit != 'true'
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip==21.3.*
         mkdir pipcache
         python -m pip install --cache-dir pipcache --no-deps openvino openvino-dev nncf
         cp -r pipcache pipcache_openvino
@@ -71,7 +71,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install texlive texlive-latex-extra pandoc
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip==21.3.*
         python -m pip install -r .ci/dev-requirements.txt --cache-dir pipcache
         python -m ipykernel install --user --name openvino_env
     - name: Make pipcache directory with OpenVINO packages

--- a/.github/workflows/install_requirements_china.yml
+++ b/.github/workflows/install_requirements_china.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip -i https://pypi.tuna.tsinghua.edu.cn/simple
+        python -m pip install --upgrade pip==21.3.* -i https://pypi.tuna.tsinghua.edu.cn/simple
         python -m pip install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
 
         python -m ipykernel install --user --name openvino_env

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Cache openvino packages
       if: steps.cachepip.outputs.cache-hit != 'true'
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip==21.3.*
         mkdir pipcache
         python -m pip install --cache-dir pipcache --no-deps openvino openvino-dev nncf
         cp -r pipcache pipcache_openvino
@@ -96,7 +96,7 @@ jobs:
         mv case_00001 notebooks/110-ct-segmentation-quantize/kits19/kits19_frames
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip==21.3.*
         python -m pip install -r .ci/dev-requirements.txt --cache-dir pipcache
         python -m ipykernel install --user --name openvino_env
     - name: Make pipcache directory with OpenVINO packages

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ cd openvino_notebooks
 
 ### Step 3: Install the Notebooks Requirements
 
-Upgrade pip to the latest version and install the requirements. Install the openvino_env kernel to create a Jupyter kernel for this virtual environment.
+Upgrade pip to version 21.3 and install the requirements. Install the openvino_env kernel to create a Jupyter kernel for this virtual environment.
 
 ```bash
-python -m pip install --upgrade pip
+python -m pip install --upgrade pip==21.3.*
 pip install -r requirements.txt
 python -m ipykernel install --user --name openvino_env
 ```


### PR DESCRIPTION
The latest pip version (22) breaks the installation of PyTorch in requirements.txt. This will probably be fixed by PyTorch soon, see `https://github.com/pytorch/pytorch/issues/72045`. For now, pinning pip to 21.3 fixes this.