### PR TITLE
Ci 112 speedup

### DIFF
--- a/.ci/test_notebooks.py
+++ b/.ci/test_notebooks.py
@@ -76,6 +76,7 @@ def test_urls_exist():
     urls = [
         "http://cs231n.stanford.edu/tiny-imagenet-200.zip",
         "https://github.com/onnx/models/raw/master/vision/style_transfer/fast_neural_style/model/pointilism-9.onnx",
+        "https://storage.openvinotoolkit.org/data/test_data/openvino_notebooks/kits19/case_00030.zip"
     ]
     opener = urllib.request.build_opener()
     opener.addheaders = [("User-agent", "Mozilla/5.0")]
@@ -87,3 +88,4 @@ def test_urls_exist():
         except urllib.error.HTTPError:
             print(f"Downloading {url} failed")
             raise
+

--- a/.ci/test_notebooks.py
+++ b/.ci/test_notebooks.py
@@ -1,3 +1,5 @@
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Set
 
@@ -26,7 +28,7 @@ def test_readme():
     """
     Test that all notebooks have a README file and exist in the Notebooks README
     """
-    notebooks_readme = Path("notebooks/README.md").read_text(encoding='utf-8')
+    notebooks_readme = Path("notebooks/README.md").read_text(encoding="utf-8")
     for item in Path("notebooks").iterdir():
         if item.is_dir():
             # item is a notebook directory
@@ -65,3 +67,23 @@ def test_requirements_binder():
     assert pip_requirements.issubset(
         binder_requirements
     ), f"Binder requirements misses: {pip_requirements.difference(binder_requirements)}"
+
+
+def test_urls_exist():
+    """
+    Test that urls that may be cached still exist on the server
+    """
+    urls = [
+        "http://cs231n.stanford.edu/tiny-imagenet-200.zip",
+        "https://github.com/onnx/models/raw/master/vision/style_transfer/fast_neural_style/model/pointilism-9.onnx",
+    ]
+    opener = urllib.request.build_opener()
+    opener.addheaders = [("User-agent", "Mozilla/5.0")]
+    urllib.request.install_opener(opener)
+    for url in urls:
+        try:
+            urlobject = urllib.request.urlopen(url, timeout=10)
+            assert urlobject.status == 200
+        except urllib.error.HTTPError:
+            print(f"Downloading {url} failed")
+            raise

--- a/.github/workflows/.env
+++ b/.github/workflows/.env
@@ -1,3 +1,3 @@
 PIP_CACHE_KEY=cache-pip-2021.4.2-1119
-FILES_CACHE_KEY=files-cache-2021.4.2-0202a
+FILES_CACHE_KEY=files-cache-2022-02-02-2
 HUB_HOME=/tmp/paddlehub

--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -54,10 +54,13 @@ jobs:
           # NOTE: when modifying cache paths, update FILES_CACHE_KEY in .env
           # and change cache paths in nbval.yml as well
           ${{ env.HUB_HOME }}
-          notebooks/208-optical-character-recognition/open_model_zoo_cache
           notebooks/110-ct-segmentation-quantize/kits19_frames_1
+          notebooks/112-pytorch-post-training-quantization-nncf/output/tiny-imagenet-200.zip
           notebooks/210-ct-scan-live-inference/kits19_frames_1
           notebooks/212-onnx-style-transfer/model
+          notebooks/302-pytorch-quantization-aware-training/data/tiny-imagenet-200.zip
+          open_model_zoo_cache
+          open_model_zoo_models
         key: ${{ env.FILES_CACHE_KEY }}
     - name: Cache openvino packages
       if: steps.cachepip.outputs.cache-hit != 'true'

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -69,10 +69,13 @@ jobs:
           # and change cache paths in convert_notebooks.yml as well
           ${{ env.HUB_HOME }}
           case_00030.zip
-          notebooks/208-optical-character-recognition/open_model_zoo_cache
           notebooks/110-ct-segmentation-quantize/kits19_frames_1
+          notebooks/112-pytorch-post-training-quantization-nncf/output/tiny-imagenet-200.zip
           notebooks/210-ct-scan-live-inference/kits19_frames_1
           notebooks/212-onnx-style-transfer/model
+          notebooks/302-pytorch-quantization-aware-training/data/tiny-imagenet-200.zip
+          open_model_zoo_cache
+          open_model_zoo_models
         key: ${{ env.FILES_CACHE_KEY }}
     - name: Cache openvino packages
       if: steps.cachepip.outputs.cache-hit != 'true'
@@ -126,5 +129,5 @@ jobs:
         jupyter lab notebooks --help
     - name: Analysing with nbval
       run: |
-        python -m pytest --nbval -x -k "test_ or notebook_utils" --durations 10 --ignore=notebooks/302-pytorch-quantization-aware-training --ignore=notebooks/112-pytorch-post-training-quantization-nncf
+        python -m pytest --nbval -x -k "test_ or notebook_utils" --durations 10
 

--- a/notebooks/112-pytorch-post-training-quantization-nncf/112-pytorch-post-training-quantization-nncf.ipynb
+++ b/notebooks/112-pytorch-post-training-quantization-nncf/112-pytorch-post-training-quantization-nncf.ipynb
@@ -162,7 +162,6 @@
     "    url: str = \"http://cs231n.stanford.edu/tiny-imagenet-200.zip\",\n",
     "    tarname: str = \"tiny-imagenet-200.zip\",\n",
     "):\n",
-    "    output_dir.mkdir(exist_ok=True)\n",
     "    archive_path = output_dir / tarname\n",
     "    download_file(url, directory=output_dir, filename=tarname)\n",
     "    zip_ref = zipfile.ZipFile(archive_path, \"r\")\n",
@@ -372,7 +371,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [],
+    "test_replace": {
+     "val_dataset,": "torch.utils.data.Subset(val_dataset, range(50)),"
+    }
+   },
    "outputs": [],
    "source": [
     "def create_dataloaders(batch_size: int = 128):\n",
@@ -484,7 +488,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "nncf_config_dict = {\n",

--- a/notebooks/302-pytorch-quantization-aware-training/302-pytorch-quantization-aware-training.ipynb
+++ b/notebooks/302-pytorch-quantization-aware-training/302-pytorch-quantization-aware-training.ipynb
@@ -135,7 +135,6 @@
     "DATA_DIR.mkdir(exist_ok=True)\n",
     "\n",
     "# Paths where PyTorch, ONNX and OpenVINO IR models will be stored\n",
-    "fp32_checkpoint_filename = Path(BASE_MODEL_NAME + \"_fp32\").with_suffix(\".pth\")\n",
     "fp32_pth_path = Path(MODEL_DIR / (BASE_MODEL_NAME + \"_fp32\")).with_suffix(\".pth\")\n",
     "fp32_onnx_path = Path(OUTPUT_DIR / (BASE_MODEL_NAME + \"_fp32\")).with_suffix(\".onnx\")\n",
     "fp32_ir_path = fp32_onnx_path.with_suffix(\".xml\")\n",
@@ -145,7 +144,7 @@
     "# It's possible to train FP32 model from scratch, but it might be slow. So the pre-trained weights are downloaded by default.\n",
     "pretrained_on_tiny_imagenet = True\n",
     "fp32_pth_url = \"https://storage.openvinotoolkit.org/repositories/nncf/openvino_notebook_ckpts/302_resnet18_fp32.pth\"\n",
-    "download_file(fp32_pth_url, directory=MODEL_DIR, filename=fp32_checkpoint_filename)"
+    "download_file(fp32_pth_url, directory=MODEL_DIR, filename=fp32_pth_path.name)"
    ]
   },
   {
@@ -182,7 +181,6 @@
     "    url=\"http://cs231n.stanford.edu/tiny-imagenet-200.zip\",\n",
     "    tarname=\"tiny-imagenet-200.zip\",\n",
     "):\n",
-    "    data_dir.mkdir(exist_ok=True)\n",
     "    archive_path = data_dir / tarname\n",
     "    download_file(url, directory=data_dir, filename=tarname)\n",
     "    zip_ref = zipfile.ZipFile(archive_path, \"r\")\n",


### PR DESCRIPTION
* Speed up 112 in CI by using a small subset of data in the test (with test_replace)
* Minor code improvement for 302 by removing `fp32_checkpoint_filename` variable and replacing with `fp32_pth_path.name`
* Added 112 and 302 back to CI, since tiny-imagenet is back online. Added tiny-imagenet zipfile to CI cache, and added function that checks that files in cache still exist on the server - that way next time a download fails temporarily, we can still run the nbval tests but the `urls_exists` test warns about the issue so we are aware of it and can take action (this does not at this moment check that cached OMZ files exist, only explicitly downloaded files).
