### PR TITLE
Update CI cache for 206/207/208

### DIFF
--- a/.github/workflows/.env
+++ b/.github/workflows/.env
@@ -1,4 +1,4 @@
-PIP_CACHE_KEY=cache-pip-2021.4.2-1119
+PIP_CACHE_KEY=cache-pip-2021.4.2_2022-02-05
 FILES_CACHE_KEY=files-cache-2022-02-05-2
 HUB_HOME=/tmp/paddlehub
 PPGAN_HOME=/tmp/paddlehub

--- a/.github/workflows/.env
+++ b/.github/workflows/.env
@@ -1,3 +1,3 @@
 PIP_CACHE_KEY=cache-pip-2021.4.2-1119
-FILES_CACHE_KEY=files-cache-2022-02-02-2
+FILES_CACHE_KEY=files-cache-2022-02-05-1
 HUB_HOME=/tmp/paddlehub

--- a/.github/workflows/.env
+++ b/.github/workflows/.env
@@ -1,3 +1,4 @@
 PIP_CACHE_KEY=cache-pip-2021.4.2-1119
-FILES_CACHE_KEY=files-cache-2022-02-05-1
+FILES_CACHE_KEY=files-cache-2022-02-05-2
 HUB_HOME=/tmp/paddlehub
+PPGAN_HOME=/tmp/paddlehub

--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -56,11 +56,11 @@ jobs:
           ${{ env.HUB_HOME }}
           notebooks/110-ct-segmentation-quantize/kits19_frames_1
           notebooks/112-pytorch-post-training-quantization-nncf/output/tiny-imagenet-200.zip
+          # 208 omz cache location is set to this with test_replace
+          notebooks/208-optical-character-recognition/open_model_zoo_cache
           notebooks/210-ct-scan-live-inference/kits19_frames_1
           notebooks/212-onnx-style-transfer/model
           notebooks/302-pytorch-quantization-aware-training/data/tiny-imagenet-200.zip
-          open_model_zoo_cache
-          open_model_zoo_models
         key: ${{ env.FILES_CACHE_KEY }}
     - name: Cache openvino packages
       if: steps.cachepip.outputs.cache-hit != 'true'

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -71,11 +71,11 @@ jobs:
           case_00030.zip
           notebooks/110-ct-segmentation-quantize/kits19_frames_1
           notebooks/112-pytorch-post-training-quantization-nncf/output/tiny-imagenet-200.zip
+          # 208 omz cache location is set to this with test_replace
+          notebooks/208-optical-character-recognition/open_model_zoo_cache
           notebooks/210-ct-scan-live-inference/kits19_frames_1
           notebooks/212-onnx-style-transfer/model
           notebooks/302-pytorch-quantization-aware-training/data/tiny-imagenet-200.zip
-          open_model_zoo_cache
-          open_model_zoo_models
         key: ${{ env.FILES_CACHE_KEY }}
     - name: Cache openvino packages
       if: steps.cachepip.outputs.cache-hit != 'true'


### PR DESCRIPTION
- Fix 208 cache location in CI (model download fails when there are too many downloads)
- Add PPGAN_HOME (same location as HUB_HOME) to cache PaddleGAN models (206/207)
- Update PIP_CACHE_KEY to fix nncf caching