### PR TITLE
Update dependency check in check_install.py

### DIFF
--- a/check_install.py
+++ b/check_install.py
@@ -34,8 +34,8 @@ def show_supported(supported):
 
 
 def pip_check():
-    result = subprocess.check_output(["pip", "check"], universal_newlines=True)
-    if "No broken requirements found" in result:
+    result = subprocess.run(["pip", "check"], universal_newlines=True, capture_output=True)
+    if "No broken requirements found" in result.stdout:
         return True, ""
     else:
         return False, result


### PR DESCRIPTION
pip used to give a warning if there were broken requirements, but now it returns an error, which caused the check_install script to print an ugly exception instead of the intended output with the error message if you had dependency conflicts. This PR fixes that and shows the error message again.

Screenshot of result with broken requirements:
![image](https://user-images.githubusercontent.com/77325899/152680440-7fc80095-2369-4f95-8033-8336b99c9497.png)

Screenshot of result after clean installation:
![image](https://user-images.githubusercontent.com/77325899/152680656-38aca0e3-fbc6-49d8-9038-3731856407ed.png)

