### PR TITLE
Fix check_install for python 3.6

### DIFF
--- a/.github/workflows/install_requirements.yml
+++ b/.github/workflows/install_requirements.yml
@@ -7,6 +7,7 @@ on:
     - 'main'
     paths:
     - '.github/workflows/install_requirements.yml'
+    - 'check_install.py'
 
 jobs:
   build_nbval:

--- a/check_install.py
+++ b/check_install.py
@@ -34,7 +34,7 @@ def show_supported(supported):
 
 
 def pip_check():
-    result = subprocess.run(["pip", "check"], universal_newlines=True, capture_output=True)
+    result = subprocess.run(["pip", "check"], universal_newlines=True, stdout=subprocess.PIPE)
     if "No broken requirements found" in result.stdout:
         return True, ""
     else:


### PR DESCRIPTION
https://github.com/openvinotoolkit/openvino_notebooks/pull/407 introduced a bug for Python 3.6 with check_install. This was not caught in the PR CI because install_requirements.yml (which runs check_install.py) was not configured to run on change of check_install.
This PR fixes the issue, and adds check_install.py to the paths of install_requirements.yml so in the future these kinds of errors are tested in the PR.