### PR TITLE
Limit macOS runs in CI

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -38,6 +38,10 @@ jobs:
         exclude:
         - os: macos-11
           python: 3.6
+        - os: macos-10.15
+          python: 3.7
+        - os: macos-10.15
+          python: 3.8
     steps:
 
     #### Installation/preparation ####


### PR DESCRIPTION
The limit on concurrent macOS runs for Github Actions runners is lower than that for other OSs and this can cause the nbval job to take a long time because the macOS jobs are still queued when other jobs have already finished.

This PR changes nbval so that it runs Python 3.6 for macos 10.15 and Python 3.7 and 3.8 for macos-11.