### PR TITLE
Add comparison of INT8 and FP32 models

### DIFF
--- a/notebooks/302-pytorch-quantization-aware-training/302-pytorch-quantization-aware-training.ipynb
+++ b/notebooks/302-pytorch-quantization-aware-training/302-pytorch-quantization-aware-training.ipynb
@@ -121,6 +121,7 @@
     "sys.path.append(\"../utils\")\n",
     "from notebook_utils import download_file\n",
     "\n",
+    "torch.manual_seed(0)\n",
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
     "print(f\"Using {device} device\")\n",
     "\n",
@@ -143,7 +144,7 @@
     "\n",
     "# It's possible to train FP32 model from scratch, but it might be slow. So the pre-trained weights are downloaded by default.\n",
     "pretrained_on_tiny_imagenet = True\n",
-    "fp32_pth_url = \"https://storage.openvinotoolkit.org/repositories/nncf/openvino_notebook_ckpts/302_resnet18_fp32.pth\"\n",
+    "fp32_pth_url = \"https://storage.openvinotoolkit.org/repositories/nncf/openvino_notebook_ckpts/302_resnet18_fp32_v1.pth\"\n",
     "download_file(fp32_pth_url, directory=MODEL_DIR, filename=fp32_pth_path.name)"
    ]
   },
@@ -186,12 +187,30 @@
     "    zip_ref = zipfile.ZipFile(archive_path, \"r\")\n",
     "    zip_ref.extractall(path=data_dir)\n",
     "    zip_ref.close()\n",
-    "    print(f\"Successfully downloaded and extracted dataset to: {data_dir}\")\n",
     "\n",
+    "def prepare_tiny_imagenet_200(dataset_dir: Path):\n",
+    "    # format validation set the same way as train set is formatted\n",
+    "    val_data_dir = dataset_dir / 'val'\n",
+    "    val_annotations_file = val_data_dir / 'val_annotations.txt'\n",
+    "    with open(val_annotations_file, 'r') as f:\n",
+    "        val_annotation_data = map(lambda line: line.split('\\t')[:2], f.readlines())\n",
+    "    val_images_dir = val_data_dir / 'images'\n",
+    "    for image_filename, image_label in val_annotation_data:\n",
+    "        from_image_filepath = val_images_dir / image_filename\n",
+    "        to_image_dir = val_data_dir / image_label\n",
+    "        if not to_image_dir.exists():\n",
+    "            to_image_dir.mkdir()\n",
+    "        to_image_filepath = to_image_dir / image_filename\n",
+    "        from_image_filepath.rename(to_image_filepath)\n",
+    "    val_annotations_file.unlink()\n",
+    "    val_images_dir.rmdir()\n",
+    "    \n",
     "\n",
     "DATASET_DIR = DATA_DIR / \"tiny-imagenet-200\"\n",
     "if not DATASET_DIR.exists():\n",
-    "    download_tiny_imagenet_200(DATA_DIR)"
+    "    download_tiny_imagenet_200(DATA_DIR)\n",
+    "    prepare_tiny_imagenet_200(DATASET_DIR)\n",
+    "    print(f\"Successfully downloaded and prepared dataset at: {DATASET_DIR}\")"
    ]
   },
   {
@@ -425,8 +444,8 @@
     "outputId": "183bdbb6-4016-463c-8d76-636a6b3a9778",
     "tags": [],
     "test_replace": {
-     "80000, 20000": "300, 100",
-     "dataset, [": "torch.utils.data.Subset(dataset, torch.arange(400)), ["
+     "train_dataset, ": "torch.utils.data.Subset(train_dataset, torch.arange(300)), ",
+     "val_dataset, ": "torch.utils.data.Subset(val_dataset, torch.arange(100)), "
     }
    },
    "outputs": [],
@@ -443,9 +462,10 @@
     "\n",
     "# Data loading code\n",
     "train_dir = DATASET_DIR / \"train\"\n",
+    "val_dir = DATASET_DIR / \"val\"\n",
     "normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])\n",
     "\n",
-    "dataset = datasets.ImageFolder(\n",
+    "train_dataset = datasets.ImageFolder(\n",
     "    train_dir,\n",
     "    transforms.Compose(\n",
     "        [\n",
@@ -456,8 +476,15 @@
     "        ]\n",
     "    ),\n",
     ")\n",
-    "train_dataset, val_dataset = torch.utils.data.random_split(\n",
-    "    dataset, [80000, 20000], generator=torch.Generator().manual_seed(0)\n",
+    "val_dataset = datasets.ImageFolder(\n",
+    "    val_dir,\n",
+    "    transforms.Compose(\n",
+    "        [\n",
+    "            transforms.Resize(image_size),\n",
+    "            transforms.ToTensor(),\n",
+    "            normalize,\n",
+    "        ]\n",
+    "    ),\n",
     ")\n",
     "\n",
     "train_loader = torch.utils.data.DataLoader(\n",
@@ -484,8 +511,6 @@
    },
    "outputs": [],
    "source": [
-    "acc1 = 0\n",
-    "best_acc1 = 0\n",
     "if pretrained_on_tiny_imagenet:\n",
     "    #\n",
     "    # ** WARNING: torch.load functionality uses Python's pickling module that\n",
@@ -494,8 +519,9 @@
     "    #\n",
     "    checkpoint = torch.load(str(fp32_pth_path), map_location=\"cpu\")\n",
     "    model.load_state_dict(checkpoint[\"state_dict\"], strict=True)\n",
-    "    best_acc1 = checkpoint[\"acc1\"]\n",
+    "    acc1_fp32 = checkpoint[\"acc1\"]\n",
     "else:\n",
+    "    best_acc1 = 0\n",
     "    # Training loop\n",
     "    for epoch in range(0, epochs):\n",
     "        # run a single training epoch\n",
@@ -510,8 +536,9 @@
     "        if is_best:\n",
     "            checkpoint = {\"state_dict\": model.state_dict(), \"acc1\": acc1}\n",
     "            torch.save(checkpoint, fp32_pth_path)\n",
-    "\n",
-    "print(f\"Accuracy of FP32 model: {best_acc1:.3f}\")"
+    "    acc1_fp32 = best_acc1\n",
+    "    \n",
+    "print(f\"Accuracy of FP32 model: {acc1_fp32:.3f}\")"
    ]
   },
   {
@@ -663,7 +690,7 @@
    "source": [
     "## Fine-tune the Compressed Model\n",
     "\n",
-    "At this step, a regular fine-tuning process is applied to restore accuracy drop. Normally, several epochs of tuning are required with a small learning rate, the same that is usually used at the end of the training of the original model. No other changes in the training pipeline are required. Here is a simple example."
+    "At this step, a regular fine-tuning process is applied to further improve quantized model accuracy. Normally, several epochs of tuning are required with a small learning rate, the same that is usually used at the end of the training of the original model. No other changes in the training pipeline are required. Here is a simple example."
    ]
   },
   {
@@ -683,9 +710,10 @@
     "train(train_loader, model, criterion, optimizer, epoch=0)\n",
     "\n",
     "# evaluate on validation set after Quantization-Aware Training (QAT case)\n",
-    "acc1 = validate(val_loader, model, criterion)\n",
+    "acc1_int8 = validate(val_loader, model, criterion)\n",
     "\n",
-    "print(f\"Accuracy of tuned INT8 model: {acc1:.3f}\")"
+    "print(f\"Accuracy of tuned INT8 model: {acc1_int8:.3f}\")\n",
+    "print(f\"Accuracy drop of tuned INT8 model over pre-trained FP32 model: {acc1_fp32 - acc1_int8:.3f}\")"
    ]
   },
   {

--- a/notebooks/305-tensorflow-quantization-aware-training/305-tensorflow-quantization-aware-training.ipynb
+++ b/notebooks/305-tensorflow-quantization-aware-training/305-tensorflow-quantization-aware-training.ipynb
@@ -75,7 +75,7 @@
     "MEAN_RGB = (0.485 * 255, 0.456 * 255, 0.406 * 255)  # From Imagenet dataset\n",
     "STDDEV_RGB = (0.229 * 255, 0.224 * 255, 0.225 * 255)  # From Imagenet dataset\n",
     "\n",
-    "fp32_pth_url = \"https://storage.openvinotoolkit.org/repositories/nncf/openvino_notebook_ckpts/305_resnet18_imagenette_fp32.h5\"\n",
+    "fp32_pth_url = \"https://storage.openvinotoolkit.org/repositories/nncf/openvino_notebook_ckpts/305_resnet18_imagenette_fp32_v1.h5\"\n",
     "_ = tf.keras.utils.get_file(fp32_h5_path.resolve(), fp32_pth_url)\n",
     "print(f'Absolute path where the model weights are saved:\\n {fp32_h5_path.resolve()}')"
    ]
@@ -103,7 +103,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasets, datasets_info = tfds.load('imagenette/160px', shuffle_files=True, as_supervised=True, with_info=True)\n",
+    "datasets, datasets_info = tfds.load('imagenette/160px', shuffle_files=True, as_supervised=True, with_info=True,\n",
+    "                                    read_config=tfds.ReadConfig(shuffle_seed=0))\n",
     "train_dataset, validation_dataset = datasets['train'], datasets['validation']\n",
     "fig = tfds.show_examples(train_dataset, datasets_info)"
    ]
@@ -251,9 +252,9 @@
     "              metrics=[tf.keras.metrics.CategoricalAccuracy(name='acc@1')])\n",
     "\n",
     "# Validate the floating-point model\n",
-    "test_loss, test_acc = model.evaluate(validation_dataset,\n",
+    "test_loss, acc_fp32 = model.evaluate(validation_dataset,\n",
     "                                     callbacks=tf.keras.callbacks.ProgbarLogger(stateful_metrics=['acc@1']))\n",
-    "print(f\"\\nAccuracy of FP32 model: {test_acc:.3f}\")"
+    "print(f\"\\nAccuracy of FP32 model: {acc_fp32:.3f}\")"
    ]
   },
   {
@@ -381,7 +382,7 @@
    "source": [
     "## Fine-tune the Compressed Model\n",
     "\n",
-    "At this step, a regular fine-tuning process is applied to restore accuracy drop. Normally, several epochs of tuning are required with a small learning rate, the same that is usually used at the end of the training of the original model. No other changes in the training pipeline are required. Here is a simple example."
+    "At this step, a regular fine-tuning process is applied to further improve quantized model accuracy. Normally, several epochs of tuning are required with a small learning rate, the same that is usually used at the end of the training of the original model. No other changes in the training pipeline are required. Here is a simple example."
    ]
   },
   {
@@ -399,12 +400,13 @@
    "source": [
     "# Train the int8 model\n",
     "model.fit(train_dataset,\n",
-    "          epochs=1)\n",
+    "          epochs=2)\n",
     "\n",
     "# Validate the int8 model\n",
-    "test_loss, test_acc = model.evaluate(validation_dataset,\n",
+    "test_loss, acc_int8 = model.evaluate(validation_dataset,\n",
     "                                     callbacks=tf.keras.callbacks.ProgbarLogger(stateful_metrics=['acc@1']))\n",
-    "print(f\"\\nAccuracy of INT8 model after fine-tuning: {test_acc:.3f}\")"
+    "print(f\"\\nAccuracy of INT8 model after fine-tuning: {acc_int8:.3f}\")\n",
+    "print(f\"\\nAccuracy drop of tuned INT8 model over pre-trained FP32 model: {acc_fp32 - acc_int8:.3f}\")"
    ]
   },
   {


### PR DESCRIPTION
Added the following features to PyTorch and Tensorflow quantization aware training notebooks
- fine-tuning of float32 model the same way as int8 model is finetuned
- accuracy comparison between fine-tuned int8 and fine-tuned float32 models

Note: nbval fails, however it also seems to fail for the `main` branch