### PR TITLE
Remove version pinning for pytorch_lightning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ tensorflow_datasets==4.2.0
 
 # CT scan training/inference requirements
 monai
-pytorch_lightning==20211126
+pytorch_lightning
 
 # Jupyter requirements
 jupyterlab
@@ -52,4 +52,3 @@ nltk>=3.6.4 # not directly required, pinned by Snyk to avoid a vulnerability
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
 scikit-learn>=0.24.2 # not directly required, pinned by Snyk to avoid a vulnerability
 paddlenlp==2.0.8 # workaround for "cannot import name '_C_ops'" error with paddlehub
-


### PR DESCRIPTION
PyTorch Lightning was pinned to a specific version in 2022.1 branch and it caused dependency conflicts when installing requirements.txt.