### PR TITLE
Remove 2021.4 version check in notebook_utils.ipynb

### DIFF
--- a/.github/workflows/.env
+++ b/.github/workflows/.env
@@ -1,4 +1,4 @@
-PIP_CACHE_KEY=cache-pip-2021.4.2_2022-02-05
+PIP_CACHE_KEY=cache-pip-2022.1.0.dev20220302
 FILES_CACHE_KEY=files-cache-2022-02-12
 USER_CACHE_KEY=user-cache-2022-02-12
 HUB_HOME=/tmp/paddlehub

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -44,6 +44,8 @@ jobs:
           python: 3.7
         - os: macos-10.15
           python: 3.8
+        - os: windows-2019
+          python: 3.6
     steps:
 
     #### Installation/preparation ####
@@ -183,13 +185,16 @@ jobs:
         jupyter lab notebooks --help
 
     # Main notebooks test. Verifies that all notebooks run without errors
+    # Temporary workaround while NNCF is not updated to TF 2.5
     - name: Analysing with nbval
+      if: ${{ matrix.python }} == '3.9' }}
       run: |
-        if [ ${{ matrix.python }} == "3.9" ]; then
           python -m pytest --nbval -k "test_ or notebook_utils" --ignore=notebooks/305-tensorflow-quantization-aware-training --durations 10
-        else
+
+    - name: Analysing with nbval
+      if: ${{ matrix.python }} != '3.9' }}
+      run: |
           python -m pytest --nbval -k "test_ or notebook_utils" --durations 10
-        fi
 
     # Show the cache after running the notebooks
     - name: Show cache

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -185,14 +185,13 @@ jobs:
         jupyter lab notebooks --help
 
     # Main notebooks test. Verifies that all notebooks run without errors
-    # Temporary workaround while NNCF is not updated to TF 2.5
+    # Temporary workaround for Python 3.9 while NNCF is not updated to TF 2.5
     - name: Analysing with nbval
-      if: ${{ matrix.python }} == '3.9' }}
+      if: matrix.python == '3.9'
       run: |
           python -m pytest --nbval -k "test_ or notebook_utils" --ignore=notebooks/305-tensorflow-quantization-aware-training --durations 10
-
     - name: Analysing with nbval
-      if: ${{ matrix.python }} != '3.9' }}
+      if: matrix.python != '3.9'
       run: |
           python -m pytest --nbval -k "test_ or notebook_utils" --durations 10
 

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -125,7 +125,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip==21.3.*
         mkdir pipcache
-        python -m pip install --cache-dir pipcache --no-deps openvino openvino-dev nncf
+        python -m pip install --cache-dir pipcache --no-deps openvino==2022.1.0.dev20220302 openvino-dev==2022.1.0.dev20220302 nncf
         cp -r pipcache pipcache_openvino
         python -m pip uninstall -y openvino openvino-dev nncf
 

--- a/notebooks/utils/notebook_utils.ipynb
+++ b/notebooks/utils/notebook_utils.ipynb
@@ -1323,20 +1323,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a6ae4c12",
-   "metadata": {
-    "tags": [
-     "hide"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "assert check_openvino_version(\"2021.4\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "41c370ef",
    "metadata": {
     "tags": [
@@ -1369,7 +1355,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openvino-dev==2022.1.0.dev20220215
+openvino-dev==2022.1.0.dev20220302
 gdown
 pytube
 yaspin


### PR DESCRIPTION
notebook_utils.ipynb still uses the old OpenVINO Core API. 
This PR only removes a test that the OpenVINO version is 2021.4, so the CI will pass with 2022.1