### PR TITLE
Temporarily disable Python 3.6 on Windows in nbval

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -42,6 +42,8 @@ jobs:
           python: 3.7
         - os: macos-10.15
           python: 3.8
+        - os: windows-2019
+          python: 3.6
     steps:
 
     #### Installation/preparation ####


### PR DESCRIPTION
nbval started failing on Windows/Python 3.6 during requirements installation. Temporarily disable this combination in CI.