### PR TITLE
CI updates for 2021.4/2022.1

### DIFF
--- a/.docker/.s2i/bin/test
+++ b/.docker/.s2i/bin/test
@@ -14,4 +14,4 @@ cp -r kits19_frames/case_00030 kits19_frames/case_00001
 
 python /tmp/scripts/patch_notebooks.py /opt/app-root/notebooks
 # Temporarily ignore 208 because of model download instability in 2021.4.2
-exec /opt/app-root/bin/pytest --durations=10 --nbval --current-env -k "test_" /opt/app-root/notebooks --ignore=/opt/app-root/notebooks/208-optical-character-recognition
+exec /opt/app-root/bin/pytest --durations=10 --nbval --current-env -k "test_" /opt/app-root/notebooks

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,4 @@
 # Build Docker image and test notebooks in Docker image
-# NOTE: 208 is currently disabled in Docker tests because of model 
-# download instability. It should be enabled again in 2022.1
 # Test script location: .docker/.s2i/bin/test
 
 name: docker_nbval

--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
     - 'main'
-    - '2022.1'
+    - '2021.4'
     paths:
     - 'notebooks/**.ipynb'
     - 'notebooks/**.py'
@@ -15,7 +15,7 @@ on:
   push:
     branches:
     - 'main'
-    - '2022.1'
+    - '2021.4'
     paths:
     - 'notebooks/**.ipynb'
     - 'notebooks/**.py'


### PR DESCRIPTION
- Run nbval CI on push/commit to 2021.4
- Delete 2022.1 branch from nbval (does not exist anymore)
- Unignore 208 from Docker tests (was ignored because of model download instability in 2021.4, this should be fixed in 2022.1) and remove warning note about that.