### PR TITLE
Temporarily exclude macOS from CI

### DIFF
--- a/.github/workflows/nbval.yml
+++ b/.github/workflows/nbval.yml
@@ -35,15 +35,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, windows-2019, macos-10.15, macos-11]
+        os: [ubuntu-18.04, ubuntu-20.04, windows-2019]
         python: [3.6, 3.7, 3.8, 3.9]
         exclude:
-        - os: macos-11
-          python: 3.6
-        - os: macos-10.15
-          python: 3.7
-        - os: macos-10.15
-          python: 3.8
         - os: windows-2019
           python: 3.6
     steps:


### PR DESCRIPTION
There are fewer macOS runners available than runners for other devices. We can temporarily disable macOS validation to free up resources for others. 