### PR TITLE
Fixed parsing of benchmark app's output

### DIFF
--- a/notebooks/112-pytorch-post-training-quantization-nncf/112-pytorch-post-training-quantization-nncf.ipynb
+++ b/notebooks/112-pytorch-post-training-quantization-nncf/112-pytorch-post-training-quantization-nncf.ipynb
@@ -679,7 +679,7 @@
    "source": [
     "def parse_benchmark_output(benchmark_output: str):\n",
     "    \"\"\"Prints the output from benchmark_app in human-readable format\"\"\"\n",
-    "    parsed_output = [line for line in benchmark_output if not (line.startswith(r\"[\") or line.startswith(\"  \") or line == \"\")]\n",
+    "    parsed_output = [line for line in benchmark_output if 'FPS' in line]\n",
     "    print(*parsed_output, sep='\\n')\n",
     "\n",
     "\n",

--- a/notebooks/302-pytorch-quantization-aware-training/302-pytorch-quantization-aware-training.ipynb
+++ b/notebooks/302-pytorch-quantization-aware-training/302-pytorch-quantization-aware-training.ipynb
@@ -816,7 +816,7 @@
    "outputs": [],
    "source": [
     "def parse_benchmark_output(benchmark_output):\n",
-    "    parsed_output = [line for line in benchmark_output if not (line.startswith(r\"[\") or line.startswith(\"  \") or line == \"\")]\n",
+    "    parsed_output = [line for line in benchmark_output if 'FPS' in line]\n",
     "    print(*parsed_output, sep='\\n')\n",
     "\n",
     "\n",

--- a/notebooks/305-tensorflow-quantization-aware-training/305-tensorflow-quantization-aware-training.ipynb
+++ b/notebooks/305-tensorflow-quantization-aware-training/305-tensorflow-quantization-aware-training.ipynb
@@ -497,7 +497,7 @@
    "outputs": [],
    "source": [
     "def parse_benchmark_output(benchmark_output):\n",
-    "    parsed_output = [line for line in benchmark_output if not (line.startswith(r\"[\") or line.startswith(\"  \") or line == \"\")]\n",
+    "    parsed_output = [line for line in benchmark_output if 'FPS' in line]\n",
     "    print(*parsed_output, sep='\\n')\n",
     "\n",
     "\n",


### PR DESCRIPTION
Changed the rule for parsing output from benchmark app.
Previous rule removed all lines including essential information about performance:
```
Benchmark FP32 model (OpenVINO IR)
Benchmark INT8 model (OpenVINO IR)
```
The ouptut is the following after the fix:
```
Benchmark FP32 model (OpenVINO IR)
[ INFO ] Throughput:   1319.79 FPS
Benchmark INT8 model (OpenVINO IR)
[ INFO ] Throughput:   4780.27 FPS
```