### PR TITLE
speedup precommit

### DIFF
--- a/.github/workflows/nbval_precommit.yml
+++ b/.github/workflows/nbval_precommit.yml
@@ -35,9 +35,9 @@ jobs:
   build_nbval:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-11, macos-12]
+        os: [ubuntu-20.04, windows-2019, macos-11]
         python: ["3.7", "3.8", "3.9", "3.10"]
     steps:
 


### PR DESCRIPTION
* reduce platforms (as openvino and python behaviour should not depends from specific os versions)
* enable fail-fast (cancel other jobs in os-python matix if one failed)