### PR TITLE
206, 207 Python API `convert_model()` used instead of console MO

### DIFF
--- a/notebooks/206-vision-paddlegan-anime/206-vision-paddlegan-anime.ipynb
+++ b/notebooks/206-vision-paddlegan-anime/206-vision-paddlegan-anime.ipynb
@@ -362,6 +362,8 @@
     "from openvino.tools import mo\n",
     "from openvino.runtime import serialize\n",
     "\n",
+    "print(\"Exporting ONNX model to OpenVINO IR... This may take a few minutes.\")\n",
+    "\n",
     "model = mo.convert_model(\n",
     "    onnx_path,\n",
     "    input_shape=[1, 3, target_height, target_width],\n",

--- a/notebooks/206-vision-paddlegan-anime/206-vision-paddlegan-anime.ipynb
+++ b/notebooks/206-vision-paddlegan-anime/206-vision-paddlegan-anime.ipynb
@@ -345,11 +345,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
-   "id": "41c3cd0b",
+   "id": "63ecd375",
    "metadata": {},
    "source": [
-    "**Convert Model to OpenVINO IR with Model Optimizer**"
+    "**Convert ONNX Model to OpenVINO IR with [Model Optimizer Python API](https://docs.openvino.ai/latest/openvino_docs_MO_DG_Python_API.html)**"
    ]
   },
   {

--- a/notebooks/206-vision-paddlegan-anime/206-vision-paddlegan-anime.ipynb
+++ b/notebooks/206-vision-paddlegan-anime/206-vision-paddlegan-anime.ipynb
@@ -29,8 +29,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install ppgan --no-deps\n",
-    "!pip install \"imageio==2.9.0\" \"imageio-ffmpeg\" \"numba>=0.53.1\" \"easydict\" \"munch\" \"natsort\""
+    "!pip install \"imageio==2.9.0\" \"imageio-ffmpeg\" \"numba>=0.53.1\" \"easydict\" \"munch\" \"natsort\"\n",
+    "!pip install ppgan --no-deps"
    ]
   },
   {
@@ -355,13 +355,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81a64832",
+   "id": "21e58ce1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "onnx_path = model_path.with_suffix(\".onnx\")\n",
-    "print(\"Exporting ONNX model to OpenVINO IR... This may take a few minutes.\")\n",
-    "!mo --input_model $onnx_path --output_dir $MODEL_DIR --input_shape \"[1,3,$target_height,$target_width]\" --model_name $MODEL_NAME --compress_to_fp16 --mean_values=\"[127.5,127.5,127.5]\" --scale_values=\"[127.5,127.5,127.5]\" --log_level \"CRITICAL\""
+    "from openvino.tools import mo\n",
+    "from openvino.runtime import serialize\n",
+    "\n",
+    "model = mo.convert_model(\n",
+    "    onnx_path,\n",
+    "    input_shape=[1, 3, target_height, target_width],\n",
+    "    mean_values=[127.5,127.5,127.5],\n",
+    "    scale_values=[127.5,127.5,127.5],\n",
+    "    compress_to_fp16=True\n",
+    ")\n",
+    "\n",
+    "# Serialize model in IR format\n",
+    "serialize(model, str(ir_path))"
    ]
   },
   {
@@ -628,7 +638,7 @@
    "hash": "ae617ccb002f72b3ab6d0069d721eac67ac2a969e83c083c4321cfcab0437cd1"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -642,7 +652,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/207-vision-paddlegan-superresolution/207-vision-paddlegan-superresolution.ipynb
+++ b/notebooks/207-vision-paddlegan-superresolution/207-vision-paddlegan-superresolution.ipynb
@@ -29,8 +29,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install ppgan --no-deps\n",
-    "!pip install \"imageio==2.9.0\" \"imageio-ffmpeg\" \"numba>=0.53.1\" \"easydict\" \"munch\" \"natsort\""
+    "!pip install \"imageio==2.9.0\" \"imageio-ffmpeg\" \"numba>=0.53.1\" \"easydict\" \"munch\" \"natsort\"\n",
+    "!pip install ppgan --no-deps"
    ]
   },
   {
@@ -297,22 +297,30 @@
    },
    "outputs": [],
    "source": [
+    "from openvino.tools import mo\n",
+    "from openvino.runtime import serialize\n",
+    "\n",
     "## Uncomment the command below to show Model Optimizer help, which shows the possible arguments for Model Optimizer.\n",
-    "# ! mo --help"
+    "# mo.convert_model(help=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed6cc19f-4b8c-4754-8473-1d905b89d476",
-   "metadata": {
-    "tags": []
-   },
+   "id": "af0d8b16",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "if not ir_path.exists():\n",
-    "    print(\"Exporting ONNX model to OpenVINO IR... This may take a few minutes.\")\n",
-    "    ! mo --input_model $onnx_path --input_shape \"[1,3,299,299]\" --model_name $MODEL_NAME --output_dir \"$MODEL_DIR\" --compress_to_fp16 --log_level \"CRITICAL\""
+    "print(\"Exporting ONNX model to OpenVINO IR... This may take a few minutes.\")\n",
+    "\n",
+    "model = mo.convert_model(\n",
+    "    onnx_path,\n",
+    "    input_shape=[1,3,299,299],\n",
+    "    compress_to_fp16=True\n",
+    ")\n",
+    "\n",
+    "# Serialize model in IR format\n",
+    "serialize(model, str(ir_path))"
    ]
   },
   {
@@ -342,6 +350,7 @@
    "source": [
     "# Read the network and get input and output names.\n",
     "ie = Core()\n",
+    "# Alternatively, the model obtained with `mo.convert_model` may be used here\n",
     "model = ie.read_model(model=ir_path)\n",
     "input_layer = model.input(0)"
    ]
@@ -549,7 +558,7 @@
    "hash": "bb0b397daf458ed78ef5a7e21732498aa92824cb15d3098f5341da903a887e15"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -563,7 +572,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/207-vision-paddlegan-superresolution/207-vision-paddlegan-superresolution.ipynb
+++ b/notebooks/207-vision-paddlegan-superresolution/207-vision-paddlegan-superresolution.ipynb
@@ -350,7 +350,7 @@
    "source": [
     "# Read the network and get input and output names.\n",
     "ie = Core()\n",
-    "# Alternatively, the model obtained with `mo.convert_model` may be used here\n",
+    "# Alternatively, the model obtained from `mo.convert_model()` may be used here\n",
     "model = ie.read_model(model=ir_path)\n",
     "input_layer = model.input(0)"
    ]

--- a/notebooks/207-vision-paddlegan-superresolution/207-vision-paddlegan-superresolution.ipynb
+++ b/notebooks/207-vision-paddlegan-superresolution/207-vision-paddlegan-superresolution.ipynb
@@ -285,7 +285,7 @@
    "id": "93f8c13a",
    "metadata": {},
    "source": [
-    "### Convert ONNX Model to OpenVINO IR"
+    "### Convert ONNX Model to OpenVINO IR with [Model Optimizer Python API](https://docs.openvino.ai/latest/openvino_docs_MO_DG_Python_API.html)"
    ]
   },
   {


### PR DESCRIPTION
This PR updates two Paddle examples (206 and 207) to use MO Python API.