### PR TITLE
Unignore 404-style-transfer notebook

### DIFF
--- a/.ci/ignore_convert_execution.txt
+++ b/.ci/ignore_convert_execution.txt
@@ -13,4 +13,3 @@ notebooks/237-segment-anything/237-segment-anything.ipynb
 notebooks/237-segment-anything/237-segment-anything-fiftyone.ipynb
 notebooks/238-deeployd-if/238-deep-floyd-if.ipynb
 notebooks/239-image-bind/239-image-bind.ipynb
-notebooks/404-style-transfer-webcam/404-style-transfer.ipynb

--- a/.ci/ignore_treon_linux.txt
+++ b/.ci/ignore_treon_linux.txt
@@ -8,4 +8,3 @@
 238-deeployd-if
 239-image-bind
 301-tensorflow-training-openvino
-404-style-transfer


### PR DESCRIPTION
Unignoring the 404-style-transfer notebook in CI pipeline. This change is intended to allow CI checks to run on this notebook, allowing to debug and ensure its functionality.