### PR TITLE
Removing mention of MYRIAD

### DIFF
--- a/notebooks/115-async-api/115-async-api.ipynb
+++ b/notebooks/115-async-api/115-async-api.ipynb
@@ -103,7 +103,7 @@
     "# read the network and corresponding weights from file\n",
     "model = ie.read_model(model=model_path)\n",
     "\n",
-    "# compile the model for the CPU (you can choose manually CPU, GPU, MYRIAD etc.)\n",
+    "# compile the model for the CPU (you can choose manually CPU, GPU etc.)\n",
     "# or let the engine choose the best available device (AUTO)\n",
     "compiled_model = ie.compile_model(model=model, device_name=\"CPU\")\n",
     "\n",


### PR DESCRIPTION
Removing mention of MYRIAD from the `Asynchronous Inference with OpenVINO` notebook.