### PR TITLE
Remove reduntant parameter num_ranking_process from 122-yolov8-quantization-with-accuracy-control

### DIFF
--- a/notebooks/122-quantizing-model-with-accuracy-control/122-yolov8-quantization-with-accuracy-control.ipynb
+++ b/notebooks/122-quantizing-model-with-accuracy-control/122-yolov8-quantization-with-accuracy-control.ipynb
@@ -312,8 +312,7 @@
     "    max_drop=0.01,\n",
     "    preset=nncf.QuantizationPreset.MIXED,\n",
     "    advanced_accuracy_restorer_parameters=AdvancedAccuracyRestorerParameters(\n",
-    "        ranking_subset_size=25,\n",
-    "        num_ranking_processes=1\n",
+    "        ranking_subset_size=25\n",
     "    ),\n",
     ")"
    ]


### PR DESCRIPTION
122-yolov8-quantization-with-accuracy-control migrated NNCF 2.6.0.  After this, setting the num_ranking_process parameter is not explicitly required.