### PR TITLE
Add NNCF quantization for InstructPix2Pix notebook

### DIFF
--- a/notebooks/231-instruct-pix2pix-image-editing/README.md
+++ b/notebooks/231-instruct-pix2pix-image-editing/README.md
@@ -24,9 +24,10 @@ The following image shows an example of the input image with text-based prompt a
 This notebook demonstrates how to convert and run stable diffusion using OpenVINO.
 
 Notebook contains the following steps:
-1. Convert PyTorch models to ONNX format.
-2. Convert ONNX models to OpenVINO IR format, using model conversion API.
-3. Run InstructPix2Pix pipeline with OpenVINO.
+1. Convert PyTorch models to OpenVINO IR format, using Model Conversion API.
+2. Run InstructPix2Pix pipeline with OpenVINO.
+3. Optimize InstructPix2Pix pipeline with [NNCF](https://github.com/openvinotoolkit/nncf/) quantization.
+4. Compare results of original and optimized pipelines.
 
 ## Installation Instructions
 


### PR DESCRIPTION
Add post-training optimization support by NNCF for UNet model from [231-instruct-pix2pix-image-editing.ipynb](https://github.com/openvinotoolkit/openvino_notebooks/blob/main/notebooks/231-instruct-pix2pix-image-editing/231-instruct-pix2pix-image-editing.ipynb)