### PR TITLE
Update utils.py

### DIFF
--- a/recipes/intelligent_queue_management/requirements.txt
+++ b/recipes/intelligent_queue_management/requirements.txt
@@ -1,5 +1,5 @@
-openvino>=2023.1.0
-nncf>=2.5.0
+openvino-dev==2023.0
+nncf==2.5.0
 ultralytics==8.0.117
 numpy==1.23.4
 pillow==9.4.0

--- a/recipes/intelligent_queue_management/utils.py
+++ b/recipes/intelligent_queue_management/utils.py
@@ -151,13 +151,18 @@ def download_file(
         directory = Path(directory)
         directory.mkdir(parents=True, exist_ok=True)
         filename = directory / Path(filename)
-    
     try:
         response = requests.get(url=url, 
-                                headers={"User-agent": "Mozilla/5.0"}, 
+                                headers={"User-agent": "Mozilla/5.0", "Accept-Encoding": "identity"},  # Added "Accept-Encoding": "identity"
                                 stream=True)
         response.raise_for_status()
-    except requests.exceptions.HTTPError as error:  # For error associated with not-200 codes. Will output something like: "404 Client Error: Not Found for url: {url}"
+    except requests.exceptions.HTTPError as error:
+    # try:
+    #     response = requests.get(url=url, 
+    #                             headers={"User-agent": "Mozilla/5.0"}, 
+    #                             stream=True)
+    #     response.raise_for_status()
+    # except requests.exceptions.HTTPError as error:  # For error associated with not-200 codes. Will output something like: "404 Client Error: Not Found for url: {url}"
         raise Exception(error) from None
     except requests.exceptions.Timeout:
         raise Exception(

--- a/recipes/intelligent_queue_management/utils.py
+++ b/recipes/intelligent_queue_management/utils.py
@@ -153,16 +153,10 @@ def download_file(
         filename = directory / Path(filename)
     try:
         response = requests.get(url=url, 
-                                headers={"User-agent": "Mozilla/5.0", "Accept-Encoding": "identity"},  # Added "Accept-Encoding": "identity"
+                                headers={"User-agent": "Mozilla/5.0", "Accept-Encoding": "identity"},
                                 stream=True)
         response.raise_for_status()
     except requests.exceptions.HTTPError as error:
-    # try:
-    #     response = requests.get(url=url, 
-    #                             headers={"User-agent": "Mozilla/5.0"}, 
-    #                             stream=True)
-    #     response.raise_for_status()
-    # except requests.exceptions.HTTPError as error:  # For error associated with not-200 codes. Will output something like: "404 Client Error: Not Found for url: {url}"
         raise Exception(error) from None
     except requests.exceptions.Timeout:
         raise Exception(

--- a/recipes/intelligent_queue_management/utils.py
+++ b/recipes/intelligent_queue_management/utils.py
@@ -156,7 +156,7 @@ def download_file(
                                 headers={"User-agent": "Mozilla/5.0", "Accept-Encoding": "identity"},
                                 stream=True)
         response.raise_for_status()
-    except requests.exceptions.HTTPError as error:
+    except requests.exceptions.HTTPError as error:  # For error associated with not-200 codes. Will output something like: "404 Client Error: Not Found for url: {url}"
         raise Exception(error) from None
     except requests.exceptions.Timeout:
         raise Exception(


### PR DESCRIPTION
Modified the `requests.get` function in `download_file` to include the "Accept-Encoding": "identity" header. This change ensures that the 'Content-length' header will return the actual file size, not the compressed size. This fixes the issue where files would be re-downloaded due to a mismatch in reported and actual file sizes.
Please refer: https://github.com/openvinotoolkit/openvino_notebooks/issues/1373