### PR TITLE
Fixing float infinity in attention-center GPU.

### DIFF
--- a/notebooks/216-attention-center/216-attention-center.ipynb
+++ b/notebooks/216-attention-center/216-attention-center.ipynb
@@ -184,6 +184,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "if \"GPU\" in device.value:\n",
+    "    core.set_property(device_name=device.value, properties={'INFERENCE_PRECISION_HINT': ov.Type.f32})\n",
     "compiled_model = core.compile_model(model=model, device_name=device.value)"
    ]
   },


### PR DESCRIPTION
Run inference-precision fp32.
Overflow because of huge FC feature depths.

Ticket: CVS-122735