### PR TITLE
reduce tf upperbound for python3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ nncf==2.6.0
 # deep learning frameworks
 tensorflow-macos>=2.5,<=2.14; sys_platform == 'darwin' and platform_machine == 'arm64' # macOS M1 and M2
 tensorflow>=2.5,<=2.14; sys_platform == 'darwin' and platform_machine != 'arm64' # macOS x86
-tensorflow>=2.5,<=2.14; sys_platform == 'linux' or platform_system == 'Windows'
+tensorflow>=2.5,<=2.14; sys_platform != 'darwin' and python_version > "3.8"
+tensorflow>=2.5,<=2.12.0; sys_platform != 'darwin' and python_version <= "3.8"
 
 onnx>=1.11.0
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
tf > 2.12 introduces upperbound for typing_extensions that lead to issues with gradio import