### PR TITLE
Fix LCM notebook due to diffusers API change

### DIFF
--- a/notebooks/263-latent-consistency-models-image-generation/263-latent-consistency-models-image-generation.ipynb
+++ b/notebooks/263-latent-consistency-models-image-generation/263-latent-consistency-models-image-generation.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "%pip install -q \"torch\" --index-url https://download.pytorch.org/whl/cpu\n",
-    "%pip install -q \"openvino>=2023.1.0\" transformers \"diffusers>=0.21.4\" pillow gradio nncf datasets"
+    "%pip install -q \"openvino>=2023.1.0\" transformers \"diffusers==0.21.4\" pillow gradio nncf datasets"
    ]
   },
   {


### PR DESCRIPTION
The LCM scheduler was refactored sometime between diffusers 0.21.4 an 0.22.1, which broke the LCM notebook. Fixing the notebook to 0.21.4 until the notebook gets rewritten to the new scheduler API.