### PR TITLE
Fix LCM notebook after upstream model update

### DIFF
--- a/notebooks/263-latent-consistency-models-image-generation/263-latent-consistency-models-image-generation.ipynb
+++ b/notebooks/263-latent-consistency-models-image-generation/263-latent-consistency-models-image-generation.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "%pip install -q \"torch\" --index-url https://download.pytorch.org/whl/cpu\n",
-    "%pip install -q \"openvino>=2023.1.0\" transformers \"diffusers>=0.21.4\" pillow gradio nncf datasets"
+    "%pip install -q \"openvino>=2023.1.0\" transformers \"diffusers==0.21.4\" pillow gradio nncf datasets"
    ]
   },
   {
@@ -87,6 +87,7 @@
     "        \"SimianLuo/LCM_Dreamshaper_v7\",\n",
     "        custom_pipeline=\"latent_consistency_txt2img\",\n",
     "        custom_revision=\"main\",\n",
+    "        revision=\"fb9c5d\",\n",
     "    )\n",
     "    scheduler = pipe.scheduler\n",
     "    tokenizer = pipe.tokenizer\n",


### PR DESCRIPTION
The upstream model for LCM_Dreamshaper_v7 got updated to work with the LCM pipeline from diffusers 0.22.0. This broke the notebook.

As suggested by the [model card](https://huggingface.co/SimianLuo/LCM_Dreamshaper_v7#usage-deprecated) README, it is required to check out a specific revision of the model to continue using the old community pipelines. This is applied in this commit, until the notebook gets upgraded to the 0.22.0 diffusers approach.