### PR TITLE
Update 263-latent-consistency-models-image-generation.ipynb

### DIFF
--- a/notebooks/263-latent-consistency-models-image-generation/263-latent-consistency-models-image-generation.ipynb
+++ b/notebooks/263-latent-consistency-models-image-generation/263-latent-consistency-models-image-generation.ipynb
@@ -87,7 +87,7 @@
     "VAE_DECODER_OV_PATH = Path(\"model/vae_decoder.xml\")\n",
     "\n",
     "\n",
-    "def load_orginal_pytorch_pipeline_componets(skip_models=False, skip_safety_checker=True):\n",
+    "def load_orginal_pytorch_pipeline_componets(skip_models=False, skip_safety_checker=False):\n",
     "    pipe = DiffusionPipeline.from_pretrained(\"SimianLuo/LCM_Dreamshaper_v7\")\n",
     "    scheduler = pipe.scheduler\n",
     "    tokenizer = pipe.tokenizer\n",


### PR DESCRIPTION
We should turn on the safety filter by default to avoid any NSFW images to be generated by default.