### PR TITLE
update standard github actions

### DIFF
--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -32,19 +32,19 @@ jobs:
     runs-on: ubuntu-20.04  # change cachepip step when changing this
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Dotenv Action
       id: dotenv
       uses: xom9ikk/dotenv@v1.0.2
       with:
         path: ./.github/workflows
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8  # change cachepip step when changing this
     - name: Cache OpenVINO Pip Packages
       id: cachepip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           pipcache

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.7'
       - name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
           # that includes the dependencies
           echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: python
           # Override the default behavior so that the action doesn't attempt
@@ -45,5 +45,5 @@ jobs:
           setup-python-dependencies: false
           
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3
 

--- a/.github/workflows/convert_notebooks.yml
+++ b/.github/workflows/convert_notebooks.yml
@@ -59,14 +59,14 @@ jobs:
     # This should ideally be a reusable workflow
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Dotenv Action
       id: dotenv
       uses: xom9ikk/dotenv@v1.0.2
       with:
         path: ./.github/workflows
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
     - name: Install required packages
@@ -78,7 +78,7 @@ jobs:
 
     - name: Cache OpenVINO Pip Packages
       id: cachepip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           pipcache
@@ -87,7 +87,7 @@ jobs:
     # Cache specific files to reduce downloads or prevent network issues
     - name: Cache Files
       id: cachefiles
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           # NOTE: when modifying cache paths, update FILES_CACHE_KEY in .env
@@ -118,7 +118,7 @@ jobs:
     # Cache PaddlePaddle cache directories to prevent CI failing due to network/download issues
     - name: Cache PaddlePaddle cache directories (per OS)
       id: cacheusercache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ env.HUB_HOME }}
@@ -174,9 +174,9 @@ jobs:
         python -m pip freeze
         python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Archive pip freeze
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: pip-freeze
+        name: pip-freeze-${{matrix.os}}-${{ matrix.python }}
         path: pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
 
     #### End installation/preparation
@@ -185,7 +185,7 @@ jobs:
       shell: bash
       run: .ci/convert_notebooks.sh
     - name: Save reStructuredText files
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: rst_files
         path: rst_files

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
             sudo rm -rf /opt/ghc
             echo "Available storage:"
             df -h
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build Docker image
       run: |
         docker build . -t openvino_notebooks

--- a/.github/workflows/generate_tags.yml
+++ b/.github/workflows/generate_tags.yml
@@ -18,21 +18,21 @@ jobs:
     runs-on: ubuntu-20.04  # change cachepip step when changing this
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Dotenv Action
       id: dotenv
       uses: xom9ikk/dotenv@v1.0.2
       with:
         path: ./.github/workflows
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Run tagger and store results in file
       run: |
         python .ci/tagger.py > notebook-tags-${{ github.sha }}.json
     - name: Archive notebook tags
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: notebook-tags
         path: notebook-tags-${{ github.sha }}.json

--- a/.github/workflows/install_requirements.yml
+++ b/.github/workflows/install_requirements.yml
@@ -16,22 +16,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-11, macos-12]
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Dotenv Action
       id: dotenv
       uses: xom9ikk/dotenv@v1.0.2
       with:
         path: ./.github/workflows
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
     - name: Cache OpenVINO Pip Packages
       id: cachepip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           pipcache
@@ -60,9 +60,9 @@ jobs:
         python -m pip freeze
         python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Archive pip freeze
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: pip-freeze
+        name: pip-freeze-${{matrix.os}}-${{ matrix.python }}
         path: pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Check install
       run: |

--- a/.github/workflows/install_requirements_china.yml
+++ b/.github/workflows/install_requirements_china.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
     - name: Install dependencies
@@ -29,9 +29,9 @@ jobs:
         python -m ipykernel install --user --name openvino_env
         python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Archive pip freeze
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: pip-freeze
+        name: pip-freeze-${{matrix.os}}-${{ matrix.python }}
         path: pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Test that `jupyter lab` works
       run: |

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ jobs:
   labelling:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Add labels (Title/Description)
       uses: github/issue-labeler@v3.1
       with:

--- a/.github/workflows/pip_conflicts_check.yml
+++ b/.github/workflows/pip_conflicts_check.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04  # change cachepip step when changing this
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Dotenv Action
       id: dotenv
@@ -28,7 +28,7 @@ jobs:
         path: ./.github/workflows
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8  # change cachepip step when changing this
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-20.04  # change cachepip step when changing this
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Dotenv Action
       id: dotenv
@@ -38,13 +38,13 @@ jobs:
         path: ./.github/workflows
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8  # change cachepip step when changing this
 
     - name: Cache OpenVINO Pip Packages
       id: cachepip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           pipcache

--- a/.github/workflows/treon.yml
+++ b/.github/workflows/treon.yml
@@ -31,7 +31,7 @@ jobs:
     # These steps are also copied to convert_notebooks.yml
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Dotenv Action
       id: dotenv
       uses: xom9ikk/dotenv@v1.0.2
@@ -44,13 +44,13 @@ jobs:
             fi
       shell: bash
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
 
     - name: Cache OpenVINO Pip Packages
       id: cachepip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           pipcache
@@ -59,7 +59,7 @@ jobs:
     # Cache specific files to reduce downloads or prevent network issues
     - name: Cache Files
       id: cachefiles
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           # NOTE: when modifying cache paths, update FILES_CACHE_KEY in .env
@@ -89,7 +89,7 @@ jobs:
     # Cache PaddlePaddle cache directories to prevent CI failing due to network/download issues
     - name: Cache PaddlePaddle cache directories
       id: cacheusercache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ env.HUB_HOME }}
@@ -147,9 +147,9 @@ jobs:
         python -m pip freeze
         python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Archive pip freeze
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: pip-freeze
+        name: pip-freeze-${{matrix.os}}-${{ matrix.python }}
         path: pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
 
     #### End installation/preparation
@@ -185,14 +185,14 @@ jobs:
             python .ci/validate_notebooks.py --ignore_list .ci/ignore_treon_mac.txt --report_dir test_report/${{matrix.os}}-${{ matrix.python }} --timeout 1200
       shell: bash
     - name: Archive test report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: test_report.csv
+        name: test_report.csv-${{matrix.os}}-${{ matrix.python }}
         path: test_report.csv
     - name: Archive notebook test report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: test_report
+        name: test_report-${{matrix.os}}-${{ matrix.python }}
         path: test_report/
 
     # Show the cache after running the notebooks

--- a/.github/workflows/treon_precommit.yml
+++ b/.github/workflows/treon_precommit.yml
@@ -46,7 +46,7 @@ jobs:
     # These steps are also copied to convert_notebooks.yml
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
           fetch-depth: 0
     
@@ -78,13 +78,13 @@ jobs:
             fi
       shell: bash
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
 
     - name: Cache OpenVINO Pip Packages
       id: cachepip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           pipcache
@@ -93,7 +93,7 @@ jobs:
     # Cache specific files to reduce downloads or prevent network issues
     - name: Cache Files
       id: cachefiles
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           # NOTE: when modifying cache paths, update FILES_CACHE_KEY in .env
@@ -124,7 +124,7 @@ jobs:
     # Cache PaddlePaddle cache directories to prevent CI failing due to network/download issues
     - name: Cache PaddlePaddle cache directories
       id: cacheusercache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ env.HUB_HOME }}
@@ -182,9 +182,9 @@ jobs:
         python -m pip freeze
         python -m pip freeze > pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
     - name: Archive pip freeze
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: pip-freeze
+        name: pip-freeze-${{matrix.os}}-${{ matrix.python }}
         path: pip-freeze-${{ github.sha }}-${{matrix.os}}-${{ matrix.python }}.txt
 
     #### End installation/preparation
@@ -220,14 +220,14 @@ jobs:
            python .ci/validate_notebooks.py --test_list test_notebooks.txt --ignore_list .ci/ignore_treon_mac.txt --report_dir test_report/${{matrix.os}}-${{ matrix.python }}
       shell: bash
     - name: Archive test report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: test_report.csv
+        name: test_report.csv-${{matrix.os}}-${{ matrix.python }}
         path: test_report.csv
     - name: Archive notebook test report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: test_report
+        name: test_report-${{matrix.os}}-${{ matrix.python }}
         path: test_report/
 
     # Show the cache after running the notebooks


### PR DESCRIPTION
* update all actions/* to their latest @v versions

* disambiguate the various pip-freeze artifacts, github now requires unique artifact names

* ditto for test-artifacts

* remove Python 3.7 from the test matrix, add Python 3.11

Fixes #1587