### PR TITLE
Added option to run a regular Whisper model in Distil-Whisper notebook

### DIFF
--- a/notebooks/267-distil-whisper-asr/267-distil-whisper-asr.ipynb
+++ b/notebooks/267-distil-whisper-asr/267-distil-whisper-asr.ipynb
@@ -77,6 +77,65 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "\n",
+    "model_ids = {\n",
+    "    \"Distil-Whisper\": [\n",
+    "        \"distil-whisper/distil-large-v2\",\n",
+    "        \"distil-whisper/distil-medium.en\",\n",
+    "        \"distil-whisper/distil-small.en\"\n",
+    "    ],\n",
+    "    \"Whisper\": [\n",
+    "        \"openai/whisper-large-v3\",\n",
+    "        \"openai/whisper-large-v2\",\n",
+    "        \"openai/whisper-large\",\n",
+    "        \"openai/whisper-medium\",\n",
+    "        \"openai/whisper-small\",\n",
+    "        \"openai/whisper-base\",\n",
+    "        \"openai/whisper-tiny\",\n",
+    "        \"openai/whisper-medium.en\",\n",
+    "        \"openai/whisper-small.en\",\n",
+    "        \"openai/whisper-base.en\",\n",
+    "        \"openai/whisper-tiny.en\",\n",
+    "    ]\n",
+    "}\n",
+    "\n",
+    "model_type = widgets.Dropdown(\n",
+    "    options=model_ids.keys(),\n",
+    "    value=\"Distil-Whisper\",\n",
+    "    description=\"Model type:\",\n",
+    "    disabled=False,\n",
+    ")\n",
+    "\n",
+    "model_type"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "model_id = widgets.Dropdown(\n",
+    "    options=model_ids[model_type.value],\n",
+    "    value=model_ids[model_type.value][0],\n",
+    "    description=\"Model:\",\n",
+    "    disabled=False,\n",
+    ")\n",
+    "\n",
+    "model_id"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
    "execution_count": 2,
    "id": "e5382431-497e-4688-b4ec-8958a92163e7",
    "metadata": {
@@ -97,12 +156,10 @@
    "source": [
     "from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq\n",
     "\n",
-    "distil_model_id = \"distil-whisper/distil-large-v2\"\n",
+    "processor = AutoProcessor.from_pretrained(model_id.value)\n",
     "\n",
-    "processor = AutoProcessor.from_pretrained(distil_model_id)\n",
-    "\n",
-    "pt_distil_model = AutoModelForSpeechSeq2Seq.from_pretrained(distil_model_id)\n",
-    "pt_distil_model.eval();"
+    "pt_model = AutoModelForSpeechSeq2Seq.from_pretrained(model_id.value)\n",
+    "pt_model.eval();"
    ]
   },
   {
@@ -196,7 +253,7 @@
    "source": [
     "import IPython.display as ipd\n",
     "\n",
-    "predicted_ids = pt_distil_model.generate(input_features)\n",
+    "predicted_ids = pt_model.generate(input_features)\n",
     "transcription = processor.batch_decode(predicted_ids, skip_special_tokens=True)\n",
     "\n",
     "display(ipd.Audio(sample[\"audio\"][\"array\"], rate=sample[\"audio\"][\"sampling_rate\"]))\n",
@@ -255,17 +312,18 @@
     "from pathlib import Path\n",
     "from optimum.intel.openvino import OVModelForSpeechSeq2Seq\n",
     "\n",
-    "distil_model_path = Path(distil_model_id.split(\"/\")[-1])\n",
+    "model_path = Path(model_id.value.replace('/', '_'))\n",
+    "ov_config = {\"CACHE_DIR\": \"\"}\n",
     "\n",
-    "if not distil_model_path.exists():\n",
-    "    ov_distil_model = OVModelForSpeechSeq2Seq.from_pretrained(\n",
-    "        distil_model_id, export=True, compile=False, load_in_8bit=False\n",
+    "if not model_path.exists():\n",
+    "    ov_model = OVModelForSpeechSeq2Seq.from_pretrained(\n",
+    "        model_id.value, ov_config=ov_config, export=True, compile=False, load_in_8bit=False\n",
     "    )\n",
-    "    ov_distil_model.half()\n",
-    "    ov_distil_model.save_pretrained(distil_model_path)\n",
+    "    ov_model.half()\n",
+    "    ov_model.save_pretrained(model_path)\n",
     "else:\n",
-    "    ov_distil_model = OVModelForSpeechSeq2Seq.from_pretrained(\n",
-    "        distil_model_path, compile=False\n",
+    "    ov_model = OVModelForSpeechSeq2Seq.from_pretrained(\n",
+    "        model_path, ov_config=ov_config, compile=False\n",
     "    )"
    ]
   },
@@ -352,8 +410,8 @@
     }
    ],
    "source": [
-    "ov_distil_model.to(device.value)\n",
-    "ov_distil_model.compile()"
+    "ov_model.to(device.value)\n",
+    "ov_model.compile()"
    ]
   },
   {
@@ -413,7 +471,7 @@
     }
    ],
    "source": [
-    "predicted_ids = ov_distil_model.generate(input_features)\n",
+    "predicted_ids = ov_model.generate(input_features)\n",
     "transcription = processor.batch_decode(predicted_ids, skip_special_tokens=True)\n",
     "\n",
     "display(ipd.Audio(sample[\"audio\"][\"array\"], rate=sample[\"audio\"][\"sampling_rate\"]))\n",
@@ -499,8 +557,8 @@
     }
    ],
    "source": [
-    "perf_distil_torch = measure_perf(pt_distil_model, sample)\n",
-    "perf_distil_ov = measure_perf(ov_distil_model, sample)"
+    "perf_torch = measure_perf(pt_model, sample)\n",
+    "perf_ov = measure_perf(ov_model, sample)"
    ]
   },
   {
@@ -525,11 +583,9 @@
     }
    ],
    "source": [
-    "print(f\"Mean torch {distil_model_path.name} generation time: {perf_distil_torch:.3f}s\")\n",
-    "print(f\"Mean openvino {distil_model_path.name} generation time: {perf_distil_ov:.3f}s\")\n",
-    "print(\n",
-    "    f\"Performance {distil_model_path.name} openvino speedup: {perf_distil_torch / perf_distil_ov:.3f}\"\n",
-    ")"
+    "print(f\"Mean torch {model_id.value} generation time: {perf_torch:.3f}s\")\n",
+    "print(f\"Mean openvino {model_id.value} generation time: {perf_ov:.3f}s\")\n",
+    "print(f\"Performance {model_id.value} openvino speedup: {perf_torch / perf_ov:.3f}\")"
    ]
   },
   {
@@ -539,154 +595,6 @@
    "source": [
     "load_in_8bit### Compare with OpenAI Whisper\n",
     "[back to top ⬆️](#Table-of-contents:)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2f8fc7eb",
-   "metadata": {},
-   "source": [
-    "Since Distil-Whisper is optimized version of original OpenAI Whisper model, let's compare performance and check benefits of using it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "5b5ba97b-539a-4aea-8f7d-1b5345a88c8c",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-11-08T15:07:37.410074400Z",
-     "start_time": "2023-11-08T15:06:45.795886200Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b270aec6d62e48178cc4d88e23969ab3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Measuring performance:   0%|          | 0/10 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "import gc\n",
-    "\n",
-    "model_id = \"openai/whisper-large-v2\"\n",
-    "model_path = Path(model_id.split(\"/\")[-1])\n",
-    "\n",
-    "pt_model = AutoModelForSpeechSeq2Seq.from_pretrained(model_id)\n",
-    "pt_model.eval()\n",
-    "\n",
-    "perf_torch = measure_perf(pt_model, sample)\n",
-    "\n",
-    "del pt_model\n",
-    "gc.collect();"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5b821138-b08a-45e3-880c-efc938d0ab25",
-   "metadata": {},
-   "source": [
-    "we can convert in OpenVINO format and run OpenAI Whisper using the same interface like its distilled version"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "49a0c1d1-70cc-4430-97ad-3849a4d204e4",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-11-08T15:08:26.533792800Z",
-     "start_time": "2023-11-08T15:07:37.409569100Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Compiling the encoder to AUTO ...\n",
-      "Compiling the decoder to AUTO ...\n",
-      "Compiling the decoder to AUTO ...\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f693544933d148609a9dc969a29cc473",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Measuring performance:   0%|          | 0/10 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "if not model_path.exists():\n",
-    "    ov_model = OVModelForSpeechSeq2Seq.from_pretrained(\n",
-    "        model_id, export=True, compile=False, load_in_8bit=False\n",
-    "    )\n",
-    "    ov_model.half()\n",
-    "    ov_model.generation_config = pt_distil_model.generation_config\n",
-    "    ov_model.save_pretrained(model_path)\n",
-    "else:\n",
-    "    ov_model = OVModelForSpeechSeq2Seq.from_pretrained(model_path, compile=False)\n",
-    "\n",
-    "ov_model.to(device.value)\n",
-    "ov_model.compile()\n",
-    "\n",
-    "perf_ov = measure_perf(ov_model, sample)\n",
-    "del ov_model\n",
-    "gc.collect();"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "d06350cc-2f80-4438-928f-881872d5971a",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-11-08T15:08:26.533792800Z",
-     "start_time": "2023-11-08T15:08:26.532663200Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "distil-large-v2 generation time in PyTorch: 3.064s\n",
-      "whisper-large-v2 generation time in PyTorch: 5.054s\n",
-      "distil-large-v2 vs whisper-large-v2 speedup in PyTorch: 1.649\n",
-      "distil-large-v2 generation time in OpenVINO: 1.819s\n",
-      "whisper-large-v2 generation time in OpenVINO: 3.815s\n",
-      "distil-large-v2 vs whisper-large-v2 speedup in OpenVINO: 2.097\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(f\"{distil_model_path.name} generation time in PyTorch: {perf_distil_torch:.3f}s\")\n",
-    "print(f\"{model_path.name} generation time in PyTorch: {perf_torch:.3f}s\")\n",
-    "print(\n",
-    "    f\"{distil_model_path.name} vs {model_path.name} speedup in PyTorch: {perf_torch / perf_distil_torch:.3f}\"\n",
-    ")\n",
-    "print(f\"{distil_model_path.name} generation time in OpenVINO: {perf_distil_ov:.3f}s\")\n",
-    "print(f\"{model_path.name} generation time in OpenVINO: {perf_ov:.3f}s\")\n",
-    "print(\n",
-    "    f\"{distil_model_path.name} vs {model_path.name} speedup in OpenVINO: {perf_ov / perf_distil_ov:.3f}\"\n",
-    ")"
    ]
   },
   {
@@ -723,11 +631,11 @@
    "source": [
     "from transformers import pipeline\n",
     "\n",
-    "ov_distil_model.generation_config = pt_distil_model.generation_config\n",
+    "ov_model.generation_config = pt_model.generation_config\n",
     "\n",
     "pipe = pipeline(\n",
     "    \"automatic-speech-recognition\",\n",
-    "    model=ov_distil_model,\n",
+    "    model=ov_model,\n",
     "    tokenizer=processor.tokenizer,\n",
     "    feature_extractor=processor.feature_extractor,\n",
     "    max_new_tokens=128,\n",
@@ -1083,7 +991,8 @@
     "    ov_model.decoder_with_past.request = InferRequestWrapper(original_decoder_with_past_request,\n",
     "                                                             decoder_calibration_data)\n",
     "\n",
-    "    calibration_dataset = load_dataset(\"hf-internal-testing/librispeech_asr_dummy\", \"clean\", split=\"validation\")\n",
+    "    calibration_dataset = load_dataset(\"librispeech_asr\", \"clean\", split=\"validation\", streaming=True)\n",
+    "    calibration_dataset = calibration_dataset.take(calibration_dataset_size)\n",
     "    for sample in tqdm(islice(calibration_dataset, calibration_dataset_size), desc=\"Collecting calibration data\",\n",
     "                       total=calibration_dataset_size):\n",
     "        input_features = extract_input_features(sample)\n",
@@ -1209,11 +1118,12 @@
    "source": [
     "%%skip not $to_quantize.value\n",
     "\n",
+    "import gc\n",
     "import shutil\n",
     "import nncf\n",
     "\n",
-    "CALIBRATION_DATASET_SIZE = 10\n",
-    "quantized_distil_model_path = Path(f\"{distil_model_path}_quantized\")\n",
+    "CALIBRATION_DATASET_SIZE = 50\n",
+    "quantized_distil_model_path = Path(f\"{model_path}_quantized\")\n",
     "\n",
     "\n",
     "def quantize(ov_model, calibration_dataset_size):\n",
@@ -1252,17 +1162,17 @@
     "        gc.collect()\n",
     "\n",
     "        # Copy the config file and the first-step-decoder manually\n",
-    "        shutil.copy(distil_model_path / \"config.json\", quantized_distil_model_path / \"config.json\")\n",
-    "        shutil.copy(distil_model_path / \"openvino_decoder_model.xml\", quantized_distil_model_path / \"openvino_decoder_model.xml\")\n",
-    "        shutil.copy(distil_model_path / \"openvino_decoder_model.bin\", quantized_distil_model_path / \"openvino_decoder_model.bin\")\n",
+    "        shutil.copy(model_path / \"config.json\", quantized_distil_model_path / \"config.json\")\n",
+    "        shutil.copy(model_path / \"openvino_decoder_model.xml\", quantized_distil_model_path / \"openvino_decoder_model.xml\")\n",
+    "        shutil.copy(model_path / \"openvino_decoder_model.bin\", quantized_distil_model_path / \"openvino_decoder_model.bin\")\n",
     "\n",
-    "    quantized_ov_model = OVModelForSpeechSeq2Seq.from_pretrained(quantized_distil_model_path, compile=False)\n",
+    "    quantized_ov_model = OVModelForSpeechSeq2Seq.from_pretrained(quantized_distil_model_path, ov_config=ov_config, compile=False)\n",
     "    quantized_ov_model.to(device.value)\n",
     "    quantized_ov_model.compile()\n",
     "    return quantized_ov_model\n",
     "\n",
     "\n",
-    "ov_quantized_distil_model = quantize(ov_distil_model, CALIBRATION_DATASET_SIZE)"
+    "ov_quantized_model = quantize(ov_model, CALIBRATION_DATASET_SIZE)"
    ]
   },
   {
@@ -1330,10 +1240,10 @@
     "sample = dataset[0]\n",
     "input_features = extract_input_features(sample)\n",
     "\n",
-    "predicted_ids = ov_distil_model.generate(input_features)\n",
+    "predicted_ids = ov_model.generate(input_features)\n",
     "transcription_original = processor.batch_decode(predicted_ids, skip_special_tokens=True)\n",
     "\n",
-    "predicted_ids = ov_quantized_distil_model.generate(input_features)\n",
+    "predicted_ids = ov_quantized_model.generate(input_features)\n",
     "transcription_quantized = processor.batch_decode(predicted_ids, skip_special_tokens=True)\n",
     "\n",
     "display(ipd.Audio(sample[\"audio\"][\"array\"], rate=sample[\"audio\"][\"sampling_rate\"]))\n",
@@ -1503,8 +1413,8 @@
     "test_dataset = test_dataset.shuffle(seed=42).take(TEST_DATASET_SIZE)\n",
     "test_samples = [sample for sample in test_dataset]\n",
     "\n",
-    "accuracy_original, times_original = calculate_transcription_time_and_accuracy(ov_distil_model, test_samples)\n",
-    "accuracy_quantized, times_quantized = calculate_transcription_time_and_accuracy(ov_quantized_distil_model, test_samples)\n",
+    "accuracy_original, times_original = calculate_transcription_time_and_accuracy(ov_model, test_samples)\n",
+    "accuracy_quantized, times_quantized = calculate_transcription_time_and_accuracy(ov_quantized_model, test_samples)\n",
     "print(f\"Encoder performance speedup: {times_original[1] / times_quantized[1]:.3f}\")\n",
     "print(f\"Decoder with past performance speedup: {times_original[2] / times_quantized[2]:.3f}\")\n",
     "print(f\"Whole pipeline performance speedup: {times_original[0] / times_quantized[0]:.3f}\")\n",
@@ -1560,27 +1470,28 @@
     "MAX_AUDIO_MINS = 30  # maximum audio input in minutes\n",
     "\n",
     "\n",
+    "generate_kwargs = {\"language\": \"en\", \"task\": \"transcribe\"} if not model_id.value.endswith(\".en\") else {}\n",
     "ov_pipe = pipeline(\n",
     "    \"automatic-speech-recognition\",\n",
-    "    model=ov_distil_model,\n",
+    "    model=ov_model,\n",
     "    tokenizer=processor.tokenizer,\n",
     "    feature_extractor=processor.feature_extractor,\n",
     "    max_new_tokens=128,\n",
     "    chunk_length_s=15,\n",
-    "    generate_kwargs={\"language\": \"en\", \"task\": \"transcribe\"},\n",
+    "    generate_kwargs=generate_kwargs,\n",
     ")\n",
     "ov_pipe_forward = ov_pipe._forward\n",
     "\n",
     "if to_quantize.value:\n",
-    "    ov_quantized_distil_model.generation_config = ov_distil_model.generation_config\n",
+    "    ov_quantized_model.generation_config = ov_model.generation_config\n",
     "    ov_quantized_pipe = pipeline(\n",
     "        \"automatic-speech-recognition\",\n",
-    "        model=ov_quantized_distil_model,\n",
+    "        model=ov_quantized_model,\n",
     "        tokenizer=processor.tokenizer,\n",
     "        feature_extractor=processor.feature_extractor,\n",
     "        max_new_tokens=128,\n",
     "        chunk_length_s=15,\n",
-    "        generate_kwargs={\"language\": \"en\", \"task\": \"transcribe\"},\n",
+    "        generate_kwargs=generate_kwargs,\n",
     "    )\n",
     "    ov_quantized_pipe_forward = ov_quantized_pipe._forward\n",
     "\n",

--- a/notebooks/267-distil-whisper-asr/267-distil-whisper-asr.ipynb
+++ b/notebooks/267-distil-whisper-asr/267-distil-whisper-asr.ipynb
@@ -994,7 +994,6 @@
     "                                                             decoder_calibration_data)\n",
     "\n",
     "    calibration_dataset = load_dataset(\"librispeech_asr\", \"clean\", split=\"validation\", streaming=True)\n",
-    "    calibration_dataset = calibration_dataset.take(calibration_dataset_size)\n",
     "    for sample in tqdm(islice(calibration_dataset, calibration_dataset_size), desc=\"Collecting calibration data\",\n",
     "                       total=calibration_dataset_size):\n",
     "        input_features = extract_input_features(sample)\n",

--- a/notebooks/267-distil-whisper-asr/267-distil-whisper-asr.ipynb
+++ b/notebooks/267-distil-whisper-asr/267-distil-whisper-asr.ipynb
@@ -70,7 +70,9 @@
     "## Load PyTorch model\n",
     "[back to top ⬆️](#Table-of-contents:)\n",
     "\n",
-    "The `AutoModelForSpeechSeq2Seq.from_pretrained` method is used for the initialization of PyTorch Whisper model using the transformers library. We will use the `distil-whisper/distil-large-v2` model as an example in this tutorial. The model will be downloaded once during first run and this process may require some time. More details about this model can be found in [model_card](https://huggingface.co/distil-whisper/distil-large-v2).\n",
+    "The `AutoModelForSpeechSeq2Seq.from_pretrained` method is used for the initialization of PyTorch Whisper model using the transformers library. By default, we will use the `distil-whisper/distil-large-v2` model as an example in this tutorial. The model will be downloaded once during first run and this process may require some time.\n",
+    "\n",
+    "You may also choose other models from [Distil-Whisper hugging face collection](https://huggingface.co/collections/distil-whisper/distil-whisper-models-65411987e6727569748d2eb6) such as `distil-whisper/distil-medium.en` or `distil-whisper/distil-small.en`. Models of the original Whisper architecture are also available, more on them [here](https://huggingface.co/openai).\n",
     "\n",
     "Preprocessing and post-processing are important in this model use. `AutoProcessor` class used for initialization `WhisperProcessor` is responsible for preparing audio input data for the model, converting it to Mel-spectrogram and decoding predicted output token_ids into string using tokenizer."
    ]

--- a/notebooks/267-distil-whisper-asr/267-distil-whisper-asr.ipynb
+++ b/notebooks/267-distil-whisper-asr/267-distil-whisper-asr.ipynb
@@ -1034,7 +1034,7 @@
      "outputs_hidden": false
     },
     "test_replace": {
-     "CALIBRATION_DATASET_SIZE = 10": "CALIBRATION_DATASET_SIZE = 1"
+     "CALIBRATION_DATASET_SIZE = 50": "CALIBRATION_DATASET_SIZE = 1"
     }
    },
    "outputs": [


### PR DESCRIPTION
Besides `distil-whisper/distil-large-v2` added options to choose between:
```
model_ids = {
    "Distil-Whisper": [
        "distil-whisper/distil-large-v2",
        "distil-whisper/distil-medium.en",
        "distil-whisper/distil-small.en"
    ],
    "Whisper": [
        "openai/whisper-large-v3",
        "openai/whisper-large-v2",
        "openai/whisper-large",
        "openai/whisper-medium",
        "openai/whisper-small",
        "openai/whisper-base",
        "openai/whisper-tiny",
        "openai/whisper-medium.en",
        "openai/whisper-small.en",
        "openai/whisper-base.en",
        "openai/whisper-tiny.en",
    ]
}
```