### PR TITLE
update langchain's api

### DIFF
--- a/notebooks/254-llm-chatbot/254-rag-chatbot.ipynb
+++ b/notebooks/254-llm-chatbot/254-rag-chatbot.ipynb
@@ -1346,7 +1346,7 @@
     "    stream_complete = Event()\n",
     "\n",
     "    def infer(question):\n",
-    "        rag_chain.run(question)\n",
+    "        rag_chain.invoke(question)\n",
     "        stream_complete.set()\n",
     "\n",
     "    t1 = Thread(target=infer, args=(history[-1][0],))\n",


### PR DESCRIPTION
As ```chain.run()``` will be removed in langchain 0.2.0, it needs be replaced with ```chain.invoke()``` 