### PR TITLE
Fix encodec version specifier

### DIFF
--- a/notebooks/encodec-audio-compression/encodec-audio-compression.ipynb
+++ b/notebooks/encodec-audio-compression/encodec-audio-compression.ipynb
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q --extra-index-url https://download.pytorch.org/whl/cpu \"openvino>=2023.3.0\" \"torch>=2.1\" \"torchaudio>=2.1\" encodec gradio \"librosa>=0.8.1\" \"matplotlib<=3.7\""
+    "%pip install -q --extra-index-url https://download.pytorch.org/whl/cpu \"openvino>=2023.3.0\" \"torch>=2.1\" \"torchaudio>=2.1\" \"encodec>=0.1.1\" gradio \"librosa>=0.8.1\" \"matplotlib<=3.7\""
    ]
   },
   {


### PR DESCRIPTION
Pip conflicts job sometimes chooses the wrong version for `encodec` that leads to the workflow failure. Examples:

- https://github.com/openvinotoolkit/openvino_notebooks/actions/runs/8450634264/job/23148442192
- https://github.com/openvinotoolkit/openvino_notebooks/actions/runs/8450587812/job/23147071962
- https://github.com/openvinotoolkit/openvino_notebooks/actions/runs/8440011027/job/23115945155

This PR specifies the stable version of encodec that should guarantee the successful installation.