### PR TITLE
[Blogs Supplementary] Employ data caching when using InferRequestWrapper

### DIFF
--- a/notebooks/267-distil-whisper-asr/267-distil-whisper-asr.ipynb
+++ b/notebooks/267-distil-whisper-asr/267-distil-whisper-asr.ipynb
@@ -116,7 +116,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "404260d231523359"
   },
   {
    "cell_type": "code",
@@ -134,7 +135,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "f820ac71e6f54295"
   },
   {
    "cell_type": "code",
@@ -951,22 +953,21 @@
     "\n",
     "def collect_calibration_dataset(ov_model: OVModelForSpeechSeq2Seq, calibration_dataset_size: int):\n",
     "    # Overwrite model request properties, saving the original ones for restoring later\n",
-    "    original_encoder_request = ov_model.encoder.request\n",
-    "    original_decoder_with_past_request = ov_model.decoder_with_past.request\n",
     "    encoder_calibration_data = []\n",
     "    decoder_calibration_data = []\n",
-    "    ov_model.encoder.request = InferRequestWrapper(original_encoder_request, encoder_calibration_data)\n",
-    "    ov_model.decoder_with_past.request = InferRequestWrapper(original_decoder_with_past_request,\n",
-    "                                                             decoder_calibration_data)\n",
+    "    ov_model.encoder.request = InferRequestWrapper(ov_model.encoder.request, encoder_calibration_data, apply_caching=True)\n",
+    "    ov_model.decoder_with_past.request = InferRequestWrapper(ov_model.decoder_with_past.request,\n",
+    "                                                             decoder_calibration_data, apply_caching=True)\n",
     "\n",
-    "    calibration_dataset = load_dataset(\"librispeech_asr\", \"clean\", split=\"validation\", streaming=True)\n",
-    "    for sample in tqdm(islice(calibration_dataset, calibration_dataset_size), desc=\"Collecting calibration data\",\n",
-    "                       total=calibration_dataset_size):\n",
-    "        input_features = extract_input_features(sample)\n",
-    "        ov_model.generate(input_features)\n",
-    "\n",
-    "    ov_model.encoder.request = original_encoder_request\n",
-    "    ov_model.decoder_with_past.request = original_decoder_with_past_request\n",
+    "    try:\n",
+    "        calibration_dataset = load_dataset(\"librispeech_asr\", \"clean\", split=\"validation\", streaming=True)\n",
+    "        for sample in tqdm(islice(calibration_dataset, calibration_dataset_size), desc=\"Collecting calibration data\",\n",
+    "                           total=calibration_dataset_size):\n",
+    "            input_features = extract_input_features(sample)\n",
+    "            ov_model.generate(input_features)\n",
+    "    finally:\n",
+    "        ov_model.encoder.request = ov_model.encoder.request.request\n",
+    "        ov_model.decoder_with_past.request = ov_model.decoder_with_past.request.request\n",
     "\n",
     "    return encoder_calibration_data, decoder_calibration_data"
    ]


### PR DESCRIPTION
Similar to #1861, but to `blogs_supplementary` branch. Useful for reproducibility of the [whisper blogpost ](https://blog.openvino.ai/blog-posts/optimizing-whisper-and-distil-whisper-for-speech-recognition-with-openvino-and-nncf).