### PR TITLE
Align optimum quantization calls with the latest API

### DIFF
--- a/notebooks/code-language-id/code-language-id.ipynb
+++ b/notebooks/code-language-id/code-language-id.ipynb
@@ -165,7 +165,7 @@
     "import evaluate\n",
     "from transformers import pipeline, AutoTokenizer, AutoModelForSequenceClassification\n",
     "from optimum.intel import OVModelForSequenceClassification\n",
-    "from optimum.intel.openvino import OVConfig, OVQuantizer\n",
+    "from optimum.intel.openvino import OVConfig, OVQuantizer, OVWeightQuantizationConfig\n",
     "from huggingface_hub.utils import RepositoryNotFoundError"
    ]
   },
@@ -559,7 +559,8 @@
     "base_model = AutoModelForSequenceClassification.from_pretrained(MODEL_ID)\n",
     "\n",
     "quantizer = OVQuantizer.from_pretrained(base_model)\n",
-    "quantization_config = OVConfig()"
+    "quantization_config = OVWeightQuantizationConfig()\n",
+    "ov_config = OVConfig(quantization_config=quantization_config)"
    ]
   },
   {
@@ -793,7 +794,7 @@
    ],
    "source": [
     "quantizer.quantize(\n",
-    "    quantization_config=quantization_config,\n",
+    "    ov_config=ov_config,\n",
     "    calibration_dataset=calibration_sample,\n",
     "    save_directory=QUANTIZED_MODEL_LOCAL_PATH,\n",
     ")"

--- a/notebooks/dolly-2-instruction-following/dolly-2-instruction-following.ipynb
+++ b/notebooks/dolly-2-instruction-following/dolly-2-instruction-following.ipynb
@@ -288,7 +288,7 @@
    ],
    "source": [
     "import gc\n",
-    "from optimum.intel import OVQuantizer\n",
+    "from optimum.intel import OVQuantizer, OVConfig, OVWeightQuantizationConfig\n",
     "\n",
     "compressed_model_path = Path(f\"{model_path}_compressed\")\n",
     "\n",
@@ -304,7 +304,8 @@
     "if to_compress.value:\n",
     "    if not compressed_model_path.exists():\n",
     "        quantizer = OVQuantizer.from_pretrained(ov_model)\n",
-    "        quantizer.quantize(save_directory=compressed_model_path, weights_only=True)\n",
+    "        ov_config = OVConfig(quantization_config=OVWeightQuantizationConfig(bits=8))\n",
+    "        quantizer.quantize(save_directory=compressed_model_path, ov_config=ov_config)\n",
     "        del quantizer\n",
     "        gc.collect()\n",
     "\n",

--- a/notebooks/named-entity-recognition/named-entity-recognition.ipynb
+++ b/notebooks/named-entity-recognition/named-entity-recognition.ipynb
@@ -315,7 +315,7 @@
    ],
    "source": [
     "from functools import partial\n",
-    "from optimum.intel import OVQuantizer\n",
+    "from optimum.intel import OVQuantizer, OVConfig, OVQuantizationConfig\n",
     "\n",
     "from optimum.intel import OVModelForTokenClassification\n",
     "\n",
@@ -341,10 +341,11 @@
     "quantized_ner_model_dir = \"quantized_ner_model\"\n",
     "\n",
     "# Apply static quantization and save the resulting model in the OpenVINO IR format\n",
+    "ov_config = OVConfig(quantization_config=OVQuantizationConfig(num_samples=len(calibration_dataset)))\n",
     "quantizer.quantize(\n",
     "    calibration_dataset=calibration_dataset,\n",
     "    save_directory=quantized_ner_model_dir,\n",
-    "    subset_size=len(calibration_dataset),\n",
+    "    ov_config=ov_config,\n",
     ")"
    ]
   },


### PR DESCRIPTION
Recently, there were some [changes ](https://github.com/huggingface/optimum-intel/pull/638)made to how NNCF quantization is called via optimum-intel. This PR updates the quantization use cases to how they are currently intended to be called.
