### PR TITLE
Unignore Style transfer in ConvertExecution

### DIFF
--- a/.ci/ignore_convert_execution.txt
+++ b/.ci/ignore_convert_execution.txt
@@ -61,7 +61,6 @@ notebooks/paint-by-example/paint-by-example.ipynb
 notebooks/stable-zephyr-3b-chatbot/stable-zephyr-3b-chatbot.ipynb
 notebooks/llm-question-answering/llm-question-answering.ipynb
 notebooks/instant-id/instant-id.ipynb
-notebooks/style-transfer-webcam/style-transfer.ipynb
 notebooks/llava-next-multimodal-chatbot/llava-next-multimodal-chatbot.ipynb
 notebooks/stable-video-diffusion/stable-video-diffusion.ipynb
 notebooks/llm-agent-langchain/llm-agent-langchain.ipynb


### PR DESCRIPTION
Updated the .ci/ignore_convert_execution.txt to exclude the style transfer notebook for execution during documentation generation. This is consistent with the changes outlined in [PR1958](https://github.com/openvinotoolkit/openvino_notebooks/pull/1958).