### PR TITLE
switch to install opencv-python-headless to avoid cannot open libGL.so.1

### DIFF
--- a/notebooks/vision-background-removal/vision-background-removal.ipynb
+++ b/notebooks/vision-background-removal/vision-background-removal.ipynb
@@ -69,7 +69,7 @@
     "import platform\n",
     "\n",
     "%pip install -q \"openvino>=2023.1.0\"\n",
-    "%pip install -q --extra-index-url https://download.pytorch.org/whl/cpu \"torch>=2.1\" opencv-python\n",
+    "%pip install -q --extra-index-url https://download.pytorch.org/whl/cpu \"torch>=2.1\" opencv-python-headless\n",
     "%pip install -q \"gdown<4.6.4\"\n",
     "\n",
     "if platform.system() != \"Windows\":\n",


### PR DESCRIPTION
fix error like this：
python -c "import cv2"

...

  File "/usr/lib64/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: libGL.so.1: cannot open shared object file: No such file or directory

Actually, opencv-python is not necessary in this notebook, opencv-python-headless is more user-friendly
