### PR TITLE
Update patch_notebooks.py to include 'openvino'

### DIFF
--- a/.ci/patch_notebooks.py
+++ b/.ci/patch_notebooks.py
@@ -61,7 +61,7 @@ def remove_ov_install(cell):
                     continue
                 if "openvino-tokenizers" in part:
                     continue
-                if "openvino>" in part or "openvino=" in part:
+                if "openvino>" in part or "openvino=" in part or "openvino" in part:
                     continue
                 if empty:
                     empty = not has_additional_deps(part)

--- a/.ci/patch_notebooks.py
+++ b/.ci/patch_notebooks.py
@@ -61,7 +61,7 @@ def remove_ov_install(cell):
                     continue
                 if "openvino-tokenizers" in part:
                     continue
-                if "openvino>" in part or "openvino=" in part or "openvino" in part:
+                if "openvino>" in part or "openvino=" in part or "openvino" == part:
                     continue
                 if empty:
                     empty = not has_additional_deps(part)


### PR DESCRIPTION
I believe we are missing removing `openvino` from notebooks while patching, what leads  to uninstalling openvino during tests:

example on `test_llm-agent-langchain.ipynb` after patching:
![image](https://github.com/openvinotoolkit/openvino_notebooks/assets/88083090/0231d242-c8ca-4e0d-ac1e-257499d56242)

This leads to next tests failing due to missing `openvino` package.