### PR TITLE
update the GPU searching function in multi GPUs

### DIFF
--- a/notebooks/auto-device/auto-device.ipynb
+++ b/notebooks/auto-device/auto-device.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "core = ov.Core()\n",
     "\n",
-    "if any('GPU' in device for device in core.available_devices) == False:\n",
+    "if not any('GPU' in device for device in core.available_devices):\n",
     "    display(\n",
     "        Markdown(\n",
     "            '<div class=\"alert alert-block alert-danger\"><b>Warning: </b> A GPU device is not available. This notebook requires GPU device to have meaningful results. </div>'\n",
@@ -367,7 +367,7 @@
     }
    ],
    "source": [
-    "if \"GPU\" not in core.available_devices:\n",
+    "if not any('GPU' in device for device in core.available_devices):\n",
     "    print(f\"A GPU device is not available. Available devices are: {core.available_devices}\")\n",
     "else:\n",
     "    # Start time.\n",

--- a/notebooks/auto-device/auto-device.ipynb
+++ b/notebooks/auto-device/auto-device.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "core = ov.Core()\n",
     "\n",
-    "if \"GPU\" not in core.available_devices:\n",
+    "if any('GPU' in device for device in core.available_devices) == False:\n",
     "    display(\n",
     "        Markdown(\n",
     "            '<div class=\"alert alert-block alert-danger\"><b>Warning: </b> A GPU device is not available. This notebook requires GPU device to have meaningful results. </div>'\n",


### PR DESCRIPTION
The original code works well in single GPU mode, and will work wrong in Multi GPUs mode, so I update the code from
```
if "GPU" not in core.available_devices:
```
to
```
if any('GPU' in device for device in core.available_devices) == False:
```