### PR TITLE
update langchain dependency

### DIFF
--- a/notebooks/llm-agent-langchain/llm-agent-langchain.ipynb
+++ b/notebooks/llm-agent-langchain/llm-agent-langchain.ipynb
@@ -57,7 +57,7 @@
     "\"accelerate\"\\\n",
     "\"openvino-nightly\"\\\n",
     "\"gradio\"\\\n",
-    "\"transformers>=4.38.1\" \"langchain>=0.1.14\" \"wikipedia\""
+    "\"transformers>=4.38.1\" \"langchain>=0.2.0\" \"langchain-community>=0.2.0\" \"wikipedia\""
    ]
   },
   {

--- a/notebooks/llm-rag-langchain/llm-rag-langchain.ipynb
+++ b/notebooks/llm-rag-langchain/llm-rag-langchain.ipynb
@@ -81,7 +81,7 @@
     "\"accelerate\"\\\n",
     "\"openvino-nightly\"\\\n",
     "\"gradio\"\\\n",
-    "\"onnx\" \"einops\" \"transformers_stream_generator\" \"tiktoken\" \"transformers>=4.38.1\" \"bitsandbytes\" \"chromadb\" \"sentence_transformers\" \"langchain>=0.1.15\" \"langchainhub\" \"unstructured\" \"scikit-learn\" \"python-docx\" \"pypdf\" "
+    "\"onnx\" \"einops\" \"transformers_stream_generator\" \"tiktoken\" \"transformers>=4.38.1\" \"bitsandbytes\" \"chromadb\" \"sentence_transformers\" \"langchain>=0.2.0\" \"langchain-community>=0.2.0\" \"langchainhub\" \"unstructured\" \"scikit-learn\" \"python-docx\" \"pypdf\" "
    ]
   },
   {


### PR DESCRIPTION
as the new [change in LangChain 0.2](https://python.langchain.com/v0.2/docs/versions/overview/#tldr), `langchain-community` will be not installed automatically with `langchain-core` and `langchain` .