### PR TITLE
set temporary upperbound for setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jupyterlab
 ipywidgets
 ipykernel>=5.*
 ipython>=7.16.3
+setuptools<70


### PR DESCRIPTION
details described in https://github.com/aws-neuron/aws-neuron-sdk/issues/893