### PR TITLE
Fix controlnet-stable-diffusion error: list index out of range

### DIFF
--- a/notebooks/controlnet-stable-diffusion/controlnet-stable-diffusion.ipynb
+++ b/notebooks/controlnet-stable-diffusion/controlnet-stable-diffusion.ipynb
@@ -1557,7 +1557,7 @@
    "metadata": {
    "test_replace": {
    "num_inference_steps = 20": "num_inference_steps = 10",
-   "subset_size = 200": "subset_size = 20"
+   "subset_size = 200": "subset_size = 30"
    }
    },
    "outputs": [],


### PR DESCRIPTION
CVS-143246
input_data >= subset_size // num_inference_steps so it should be >= 3 as we use 3 elements from input_data 
 in calculate_inference_time.
num_inference_steps is replaced on 10 in test, subset_size is replaced on 20. subset_size is increased to 30.