### PR TITLE
Fix error in demo of enabling sparse weight decompression feature

### DIFF
--- a/notebooks/sparsity-optimization/sparsity-optimization.ipynb
+++ b/notebooks/sparsity-optimization/sparsity-optimization.ipynb
@@ -241,7 +241,7 @@
     "    outfile.write(\n",
     "        \"\"\"\n",
     "        {\n",
-    "            \"CPU\": {\"NUM_STREAMS\": 4, \"INFERENCE_NUM_THREADS\": 4, \"CPU_SPARSE_WEIGHTS_DECOMPRESSION_RATE\": 0.75}\n",
+    "            \"CPU\": {\"NUM_STREAMS\": 4, \"INFERENCE_NUM_THREADS\": 4, \"CPU_SPARSE_WEIGHTS_DECOMPRESSION_RATE\": \"0.75\"}\n",
     "        }\n",
     "        \"\"\"\n",
     "    )"


### PR DESCRIPTION
The value needs to be between double quotes, otherwise it gives an error asking for the value to be a float.