### PR TITLE
fix typo in stable-video-diffusion

### DIFF
--- a/notebooks/stable-video-diffusion/stable-video-diffusion.ipynb
+++ b/notebooks/stable-video-diffusion/stable-video-diffusion.ipynb
@@ -1579,7 +1579,7 @@
    "source": [
     "int8_out_path = Path(\"generated_int8.mp4\")\n",
     "\n",
-    "export_to_video(frames, str(out_path), fps=7)\n",
+    "export_to_video(int8_frames, str(int8_out_path), fps=7)\n",
     "int8_frames[0].save(\n",
     "    \"generated_int8.gif\",\n",
     "    save_all=True,\n",


### PR DESCRIPTION
fix typo in `export_to_video` for the output from int8 model