### PR TITLE
Update to make SD3 deterministic

### DIFF
--- a/notebooks/stable-diffusion-v3/sd3_helper.py
+++ b/notebooks/stable-diffusion-v3/sd3_helper.py
@@ -759,7 +759,7 @@ class OVStableDiffusion3Pipeline(DiffusionPipeline):
                     noise_pred = noise_pred_uncond + self.guidance_scale * (noise_pred_text - noise_pred_uncond)
 
                 # compute the previous noisy sample x_t -> x_t-1
-                latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+                latents = self.scheduler.step(noise_pred, t, latents, return_dict=False, generator=generator)[0]
 
                 if callback_on_step_end is not None:
                     callback_kwargs = {}


### PR DESCRIPTION
Currently, it generates different images every run especially if `flash_lora` is selected.
This PR updates `OVStableDiffusion3Pipeline` to pass `generator` when calling scheduler.step().