### PR TITLE
fix triposr installation on windows

### DIFF
--- a/notebooks/triposr-3d-reconstruction/triposr-3d-reconstruction.ipynb
+++ b/notebooks/triposr-3d-reconstruction/triposr-3d-reconstruction.ipynb
@@ -56,7 +56,7 @@
    "outputs": [],
    "source": [
     "%pip install -q \"gradio>=4.19\" \"torch==2.2.2\" \"torchvision<0.18.0\" rembg trimesh einops \"omegaconf>=2.3.0\" \"transformers>=4.35.0\" \"openvino>=2024.0.0\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
-    "%pip install -q \"git+https://github.com/tatsy/torchmcubes.git\" --extra-index-url https://download.pytorch.org/whl/cpu"
+    "%pip install \"git+https://github.com/tatsy/torchmcubes.git@cbb3c3795b1e168bf81e8dee28623eaf5c33cd1c\" --extra-index-url https://download.pytorch.org/whl/cpu"
    ]
   },
   {
@@ -634,7 +634,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.8"
   },
   "openvino_notebooks": {
    "imageUrl": "https://github.com/VAST-AI-Research/TripoSR/blob/main/figures/teaser800.gif?raw=true",


### PR DESCRIPTION
torchcubes project moved on scikit-build building system that uses unsupported cmake command for windows, pin torchcubes version without these changes