### PR TITLE
Update hello-npu.ipynb

### DIFF
--- a/notebooks/hello-npu/hello-npu.ipynb
+++ b/notebooks/hello-npu/hello-npu.ipynb
@@ -310,7 +310,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import hugginface_hub as hf_hub"
+    "import huggingface_hub as hf_hub"
    ]
   },
   {


### PR DESCRIPTION
Huggingface was misspelled as 'Hugginface', causing the script to fail at block 6