### PR TITLE
Exclude GPU device for grammar correction notebook

### DIFF
--- a/notebooks/grammar-correction/grammar-correction.ipynb
+++ b/notebooks/grammar-correction/grammar-correction.ipynb
@@ -224,7 +224,7 @@
     "\n",
     "from notebook_utils import device_widget\n",
     "\n",
-    "device = device_widget()\n",
+    "device = device_widget(default=\"CPU\", exclude=[\"AUTO\", \"GPU\"])\n",
     "\n",
     "device"
    ]
@@ -950,6 +950,7 @@
    ],
    "source": [
     "from utils import get_quantized_pipeline, CALIBRATION_DATASET_SIZE\n",
+    "import openvino as ov\n",
     "\n",
     "grammar_corrector_pipe_fp32 = grammar_corrector_pipe\n",
     "grammar_corrector_pipe_int8 = None\n",
@@ -958,7 +959,7 @@
     "    grammar_corrector_pipe_int8 = get_quantized_pipeline(\n",
     "        grammar_corrector_pipe_fp32,\n",
     "        grammar_corrector_tokenizer,\n",
-    "        core,\n",
+    "        ov.Core(),\n",
     "        grammar_corrector_dir,\n",
     "        quantized_model_path,\n",
     "        device.value,\n",


### PR DESCRIPTION
There are accuracy issues for grammar correction encoder model on GPU

**Ticket**
127998