### PR TITLE
switch the order of llamaindex installation

### DIFF
--- a/notebooks/llm-agent-react/llm-agent-rag-llamaindex.ipynb
+++ b/notebooks/llm-agent-react/llm-agent-rag-llamaindex.ipynb
@@ -96,6 +96,8 @@
     "    \"llama-index-llms-huggingface\",\n",
     "    \"llama-index-embeddings-huggingface\",\n",
     "    \"transformers>=4.43.1\",\n",
+    "    \"llama-index-llms-huggingface>=0.3.0,<0.3.4\",\n",
+    "    \"llama-index-embeddings-huggingface>=0.3.0\",\n",
     ")\n",
     "pip_install(\"-q\", \"git+https://github.com/huggingface/optimum-intel.git\", \"git+https://github.com/openvinotoolkit/nncf.git\", \"datasets\", \"accelerate\")\n",
     "pip_install(\"--pre\", \"-Uq\", \"openvino>=2024.2.0\", \"--extra-index-url\", \"https://storage.openvinotoolkit.org/simple/wheels/nightly\")\n",

--- a/notebooks/llm-rag-llamaindex/llm-rag-llamaindex.ipynb
+++ b/notebooks/llm-rag-llamaindex/llm-rag-llamaindex.ipynb
@@ -115,6 +115,8 @@
     "    \"llama-index-readers-file\",\n",
     "    \"llama-index-vector-stores-faiss\",\n",
     "    \"llama-index-llms-langchain\",\n",
+    "    \"llama-index-llms-huggingface>=0.3.0,<0.3.4\",\n",
+    "    \"llama-index-embeddings-huggingface>=0.3.0\",\n",
     ")\n",
     "pip_install(\"-q\", \"git+https://github.com/huggingface/optimum-intel.git\", \"git+https://github.com/openvinotoolkit/nncf.git\", \"datasets\", \"accelerate\", \"gradio\")\n",
     "pip_install(\"--pre\", \"-U\", \"openvino>=2024.2\", \"--extra-index-url\", \"https://storage.openvinotoolkit.org/simple/wheels/nightly\")\n",


### PR DESCRIPTION
there are dependencies in llama-index-llms-openvino installation

[llama-index-llms-openvino](https://github.com/run-llama/llama_index/blob/main/llama-index-integrations/llms/llama-index-llms-openvino/pyproject.toml#L37)