### PR TITLE
Fixed up the benchmark missing parameters and add verbose=False

### DIFF
--- a/notebooks/yolov11-optimization/yolov11-instance-segmentation.ipynb
+++ b/notebooks/yolov11-optimization/yolov11-instance-segmentation.ipynb
@@ -1041,7 +1041,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "4c7bb92e-e301-45a9-b5ff-f7953fad298f",
    "metadata": {},
    "outputs": [],
@@ -1108,7 +1108,7 @@
     "            input_image = np.array(frame)\n",
     "\n",
     "            start_time = time.time()\n",
-    "            detections = seg_model(input_image)\n",
+    "            detections = seg_model(input_image, verbose=False)\n",
     "            stop_time = time.time()\n",
     "            frame = detections[0].plot()\n",
     "\n",

--- a/notebooks/yolov11-optimization/yolov11-keypoint-detection.ipynb
+++ b/notebooks/yolov11-optimization/yolov11-keypoint-detection.ipynb
@@ -959,7 +959,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "b9b07129-ec21-40e0-9885-1928ace8a55a",
    "metadata": {},
    "outputs": [
@@ -1053,7 +1053,7 @@
    "source": [
     "if int8_model_pose_path.exists():\n",
     "    # Inference FP32 model (OpenVINO IR)\n",
-    "    !benchmark_app -m $pose_model_path -d $device.value -api async -shape \"[1,3,640,640]\""
+    "    !benchmark_app -m $pose_model_path -d $device.value -api async -shape \"[1,3,640,640]\" -t 15"
    ]
   },
   {
@@ -1199,7 +1199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "4c7bb92e-e301-45a9-b5ff-f7953fad298f",
    "metadata": {},
    "outputs": [],
@@ -1267,7 +1267,7 @@
     "\n",
     "            start_time = time.time()\n",
     "\n",
-    "            detections = pose_model(input_image)\n",
+    "            detections = pose_model(input_image, verbose=False)\n",
     "            stop_time = time.time()\n",
     "            frame = detections[0].plot()\n",
     "\n",
@@ -1331,11 +1331,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "90708017",
    "metadata": {},
    "outputs": [],
    "source": [
+    "#VIDEO_SOURCE = 0 #for webcam\n",
     "VIDEO_SOURCE = \"https://storage.openvinotoolkit.org/repositories/openvino_notebooks/data/data/video/people.mp4\""
    ]
   },

--- a/notebooks/yolov11-optimization/yolov11-object-detection.ipynb
+++ b/notebooks/yolov11-optimization/yolov11-object-detection.ipynb
@@ -752,7 +752,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "b9b07129-ec21-40e0-9885-1928ace8a55a",
    "metadata": {},
    "outputs": [
@@ -846,7 +846,7 @@
    "source": [
     "if int8_model_det_path.exists():\n",
     "    # Inference FP32 model (OpenVINO IR)\n",
-    "    !benchmark_app -m $det_model_path -d $device.value -api async -shape \"[1,3,640,640]\""
+    "    !benchmark_app -m $det_model_path -d $device.value -api async -shape \"[1,3,640,640]\" -t 15"
    ]
   },
   {


### PR DESCRIPTION
This will reduce the extra time in the benchmark under FP32 models and also reduce print statements (lags) in video inferencing