### PR TITLE
instant-id: added deleting of full precision pipeline before quantization

### DIFF
--- a/notebooks/instant-id/instant-id.ipynb
+++ b/notebooks/instant-id/instant-id.ipynb
@@ -1811,43 +1811,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "e111bc7e-fac9-4881-a3d2-f39057f369b6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "text_encoder = core.compile_model(ov_text_encoder_path, device.value)\n",
-    "text_encoder_2 = core.compile_model(ov_text_encoder_2_path, device.value)\n",
-    "vae_decoder = core.compile_model(ov_vae_decoder_path, device.value)\n",
-    "unet = core.compile_model(ov_unet_path, device.value)\n",
-    "controlnet = core.compile_model(ov_controlnet_path, device.value)\n",
-    "image_proj_model = core.compile_model(ov_image_proj_encoder_path, device.value)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "id": "652b2d05-bd26-46c1-ba09-96f27db970e8",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The config attributes {'interpolation_type': 'linear', 'skip_prk_steps': True, 'use_karras_sigmas': False} were passed to LCMScheduler, but are not expected and will be ignored. Please verify your scheduler_config.json configuration file.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from transformers import AutoTokenizer\n",
-    "\n",
-    "tokenizer = AutoTokenizer.from_pretrained(MODELS_DIR / \"tokenizer\")\n",
-    "tokenizer_2 = AutoTokenizer.from_pretrained(MODELS_DIR / \"tokenizer_2\")\n",
-    "scheduler = LCMScheduler.from_pretrained(MODELS_DIR / \"scheduler\")"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "3772ef85-8419-4f4a-bef7-7fd0061f3e09",
@@ -1864,17 +1827,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ov_pipe = OVStableDiffusionXLInstantIDPipeline(\n",
-    "    text_encoder,\n",
-    "    text_encoder_2,\n",
-    "    image_proj_model,\n",
-    "    controlnet,\n",
-    "    unet,\n",
-    "    vae_decoder,\n",
-    "    tokenizer,\n",
-    "    tokenizer_2,\n",
-    "    scheduler,\n",
-    ")"
+    "from transformers import AutoTokenizer\n",
+    "\n",
+    "def create_ov_pipe():\n",
+    "    return OVStableDiffusionXLInstantIDPipeline(\n",
+    "        core.compile_model(ov_text_encoder_path, device.value),\n",
+    "        core.compile_model(ov_text_encoder_2_path, device.value),\n",
+    "        core.compile_model(ov_image_proj_encoder_path, device.value),\n",
+    "        core.compile_model(ov_controlnet_path, device.value),\n",
+    "        core.compile_model(ov_unet_path, device.value),\n",
+    "        core.compile_model(ov_vae_decoder_path, device.value),\n",
+    "        AutoTokenizer.from_pretrained(MODELS_DIR / \"tokenizer\"),\n",
+    "        AutoTokenizer.from_pretrained(MODELS_DIR / \"tokenizer_2\"),\n",
+    "        LCMScheduler.from_pretrained(MODELS_DIR / \"scheduler\"),\n",
+    "    )\n",
+    "\n",
+    "ov_pipe = create_ov_pipe()"
    ]
   },
   {
@@ -2258,6 +2226,20 @@
     "\n",
     "Quantization of the first `Convolution` layer impacts the generation results. We recommend using `IgnoredScope` to keep accuracy sensitive layers in FP16 precision."
    ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "%%skip not $to_quantize.value\n",
+    "\n",
+    "# Delete loaded full precision pipeline before quantization to lower peak memory footprint.\n",
+    "del ov_pipe\n",
+    "gc.collect()"
+   ],
+   "id": "af9de11ca348fd83"
   },
   {
    "cell_type": "code",
@@ -4430,6 +4412,11 @@
     "optimized_text_encoder_2 = core.compile_model(ov_int8_text_encoder_2_path, device.value)\n",
     "optimized_vae_decoder = core.compile_model(ov_int8_vae_decoder_path, device.value)\n",
     "\n",
+    "image_proj_model = core.compile_model(ov_image_proj_encoder_path, device.value)\n",
+    "tokenizer = AutoTokenizer.from_pretrained(MODELS_DIR / \"tokenizer\")\n",
+    "tokenizer_2 = AutoTokenizer.from_pretrained(MODELS_DIR / \"tokenizer_2\")\n",
+    "scheduler = LCMScheduler.from_pretrained(MODELS_DIR / \"scheduler\")\n",
+    "\n",
     "int8_pipe = OVStableDiffusionXLInstantIDPipeline(\n",
     "    optimized_text_encoder,\n",
     "    optimized_text_encoder_2,\n",
@@ -4485,7 +4472,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %%skip not $to_quantize.value\n",
+    "%%skip not $to_quantize.value\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
@@ -4595,8 +4582,30 @@
     "\n",
     "To measure the inference performance of the `FP16` and `INT8` pipelines, we use mean inference time on 5 samples.\n",
     "\n",
-    "> **NOTE**: For the most accurate performance estimation, it is recommended to run `benchmark_app` in a terminal/command prompt after closing other applications."
+    "Please select below wether you would like to run inference time comparison.\n",
+    "\n",
+    "> **NOTE**: For the most accurate performance estimation, it is recommended to run `benchmark_app` in a terminal/command prompt after closing other applications.\n",
+    "\n",
+    "> **NOTE**: This is a memory consuming step because two pipelines need to be loaded at the same time."
    ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import ipywidgets as widgets\n",
+    "\n",
+    "run_inference_time_comparison = widgets.Checkbox(\n",
+    "    value=False,\n",
+    "    description=\"Inference time comparison\",\n",
+    "    disabled=not to_quantize.value,\n",
+    ")\n",
+    "\n",
+    "run_inference_time_comparison"
+   ],
+   "id": "7ca23440083f3bb4"
   },
   {
    "cell_type": "code",
@@ -4605,7 +4614,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%skip not $to_quantize.value\n",
+    "%%skip (not $to_quantize.value or not $run_inference_time_comparison.value)\n",
     "\n",
     "import time\n",
     "\n",
@@ -4634,6 +4643,19 @@
    ]
   },
   {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "%%skip (not $to_quantize.value or not $run_inference_time_comparison.value)\n",
+    "\n",
+    "# Load full precision pipeline\n",
+    "ov_pipe = create_ov_pipe()"
+   ],
+   "id": "1ab19a417e7cd264"
+  },
+  {
    "cell_type": "code",
    "execution_count": 45,
    "id": "1ce11624",
@@ -4650,7 +4672,7 @@
     }
    ],
    "source": [
-    "%%skip not $to_quantize.value\n",
+    "%%skip (not $to_quantize.value or not $run_inference_time_comparison.value)\n",
     "\n",
     "fp_latency = calculate_inference_time(ov_pipe, face_info)\n",
     "print(f\"FP16 pipeline: {fp_latency:.3f} seconds\")\n",
@@ -4706,6 +4728,21 @@
     "\n",
     "use_quantized_models"
    ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "if use_quantized_models.value:\n",
+    "    if ov_pipe is not None:\n",
+    "        del ov_pipe\n",
+    "        gc.collect()\n",
+    "elif ov_pipe is None:\n",
+    "    ov_pipe = create_ov_pipe()"
+   ],
+   "id": "728fb893f25d854f"
   },
   {
    "cell_type": "code",
@@ -5011,7 +5048,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Statistics collection <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">200/200</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:14:43</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Statistics collection \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m200/200\u001b[0m • \u001b[38;2;0;104;181m0:14:43\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Statistics collection \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m200/200\u001B[0m • \u001B[38;2;0;104;181m0:14:43\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5057,7 +5094,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Weight Compression <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">40/40</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Weight Compression \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m40/40\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Weight Compression \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m40/40\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5126,7 +5163,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Fast Bias correction <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">197/197</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:41</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Fast Bias correction \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m197/197\u001b[0m • \u001b[38;2;0;104;181m0:00:41\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Fast Bias correction \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m197/197\u001B[0m • \u001B[38;2;0;104;181m0:00:41\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5166,7 +5203,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Statistics collection <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">200/200</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:09:21</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Statistics collection \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m200/200\u001b[0m • \u001b[38;2;0;104;181m0:09:21\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Statistics collection \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m200/200\u001B[0m • \u001B[38;2;0;104;181m0:09:21\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5190,7 +5227,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Fast Bias correction <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">51/51</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:17</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Fast Bias correction \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m51/51\u001b[0m • \u001b[38;2;0;104;181m0:00:17\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Fast Bias correction \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m51/51\u001B[0m • \u001B[38;2;0;104;181m0:00:17\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5208,7 +5245,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Weight Compression <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">195/195</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:04</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Weight Compression \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m195/195\u001b[0m • \u001b[38;2;0;104;181m0:00:04\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Weight Compression \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m195/195\u001B[0m • \u001B[38;2;0;104;181m0:00:04\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5226,7 +5263,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Smooth Quant <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">220/220</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:20</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Smooth Quant \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m220/220\u001b[0m • \u001b[38;2;0;104;181m0:00:20\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Smooth Quant \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m220/220\u001B[0m • \u001B[38;2;0;104;181m0:00:20\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5364,7 +5401,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Weight Compression <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">74/74</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Weight Compression \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m74/74\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Weight Compression \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m74/74\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5450,7 +5487,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Statistics collection <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">200/200</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:04:15</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Statistics collection \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m200/200\u001b[0m • \u001b[38;2;0;104;181m0:04:15\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Statistics collection \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m200/200\u001B[0m • \u001B[38;2;0;104;181m0:04:15\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5526,7 +5563,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Weight Compression <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">883/883</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:17</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Weight Compression \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m883/883\u001b[0m • \u001b[38;2;0;104;181m0:00:17\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Weight Compression \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m883/883\u001B[0m • \u001B[38;2;0;104;181m0:00:17\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"

--- a/notebooks/instant-id/instant-id.ipynb
+++ b/notebooks/instant-id/instant-id.ipynb
@@ -4582,7 +4582,7 @@
     "\n",
     "To measure the inference performance of the `FP16` and `INT8` pipelines, we use mean inference time on 5 samples.\n",
     "\n",
-    "Please select below wether you would like to run inference time comparison.\n",
+    "Please select below whether you would like to run inference time comparison.\n",
     "\n",
     "> **NOTE**: For the most accurate performance estimation, it is recommended to run `benchmark_app` in a terminal/command prompt after closing other applications.\n",
     "\n",

--- a/notebooks/instant-id/instant-id.ipynb
+++ b/notebooks/instant-id/instant-id.ipynb
@@ -1979,8 +1979,8 @@
    "source": [
     "from notebook_utils import quantization_widget\n",
     "\n",
-    "skip_for_device = \"GPU\" in device.value\n",
-    "to_quantize = quantization_widget(skip_for_device)\n",
+    "skip_for_device = \"GPU\" in device.value or (device.value == \"AUTO\" and any(\"GPU\" in device_name for device_name in core.available_devices))\n",
+    "to_quantize = quantization_widget(not skip_for_device)\n",
     "to_quantize"
    ]
   },

--- a/notebooks/instant-id/instant-id.ipynb
+++ b/notebooks/instant-id/instant-id.ipynb
@@ -1829,6 +1829,7 @@
    "source": [
     "from transformers import AutoTokenizer\n",
     "\n",
+    "\n",
     "def create_ov_pipe():\n",
     "    return OVStableDiffusionXLInstantIDPipeline(\n",
     "        core.compile_model(ov_text_encoder_path, device.value),\n",
@@ -1841,6 +1842,7 @@
     "        AutoTokenizer.from_pretrained(MODELS_DIR / \"tokenizer_2\"),\n",
     "        LCMScheduler.from_pretrained(MODELS_DIR / \"scheduler\"),\n",
     "    )\n",
+    "\n",
     "\n",
     "ov_pipe = create_ov_pipe()"
    ]
@@ -5048,7 +5050,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Statistics collection <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">200/200</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:14:43</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Statistics collection \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m200/200\u001B[0m • \u001B[38;2;0;104;181m0:14:43\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
+          "text/plain": "Statistics collection \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m200/200\u001b[0m • \u001b[38;2;0;104;181m0:14:43\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5094,7 +5096,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Weight Compression <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">40/40</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Weight Compression \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m40/40\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
+          "text/plain": "Applying Weight Compression \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m40/40\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5163,7 +5165,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Fast Bias correction <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">197/197</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:41</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Fast Bias correction \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m197/197\u001B[0m • \u001B[38;2;0;104;181m0:00:41\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
+          "text/plain": "Applying Fast Bias correction \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m197/197\u001b[0m • \u001b[38;2;0;104;181m0:00:41\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5203,7 +5205,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Statistics collection <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">200/200</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:09:21</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Statistics collection \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m200/200\u001B[0m • \u001B[38;2;0;104;181m0:09:21\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
+          "text/plain": "Statistics collection \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m200/200\u001b[0m • \u001b[38;2;0;104;181m0:09:21\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5227,7 +5229,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Fast Bias correction <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">51/51</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:17</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Fast Bias correction \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m51/51\u001B[0m • \u001B[38;2;0;104;181m0:00:17\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
+          "text/plain": "Applying Fast Bias correction \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m51/51\u001b[0m • \u001b[38;2;0;104;181m0:00:17\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5245,7 +5247,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Weight Compression <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">195/195</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:04</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Weight Compression \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m195/195\u001B[0m • \u001B[38;2;0;104;181m0:00:04\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
+          "text/plain": "Applying Weight Compression \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m195/195\u001b[0m • \u001b[38;2;0;104;181m0:00:04\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5263,7 +5265,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Smooth Quant <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">220/220</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:20</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Smooth Quant \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m220/220\u001B[0m • \u001B[38;2;0;104;181m0:00:20\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
+          "text/plain": "Applying Smooth Quant \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m220/220\u001b[0m • \u001b[38;2;0;104;181m0:00:20\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5401,7 +5403,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Weight Compression <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">74/74</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Weight Compression \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m74/74\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
+          "text/plain": "Applying Weight Compression \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m74/74\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5487,7 +5489,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Statistics collection <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">200/200</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:04:15</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Statistics collection \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m200/200\u001B[0m • \u001B[38;2;0;104;181m0:04:15\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
+          "text/plain": "Statistics collection \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m200/200\u001b[0m • \u001b[38;2;0;104;181m0:04:15\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5563,7 +5565,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Weight Compression <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">883/883</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:17</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Weight Compression \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m883/883\u001B[0m • \u001B[38;2;0;104;181m0:00:17\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
+          "text/plain": "Applying Weight Compression \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m883/883\u001b[0m • \u001b[38;2;0;104;181m0:00:17\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"

--- a/notebooks/instant-id/instant-id.ipynb
+++ b/notebooks/instant-id/instant-id.ipynb
@@ -1830,21 +1830,41 @@
     "from transformers import AutoTokenizer\n",
     "\n",
     "\n",
-    "def create_ov_pipe():\n",
+    "def create_ov_pipe(\n",
+    "    text_encoder_path,\n",
+    "    text_encoder_2_path,\n",
+    "    image_proj_encoder_path,\n",
+    "    controlnet_path,\n",
+    "    unet_path,\n",
+    "    vae_decoder_path,\n",
+    "    tokenizer_path,\n",
+    "    tokenizer_2_path,\n",
+    "    scheduler_path,\n",
+    "):\n",
     "    return OVStableDiffusionXLInstantIDPipeline(\n",
-    "        core.compile_model(ov_text_encoder_path, device.value),\n",
-    "        core.compile_model(ov_text_encoder_2_path, device.value),\n",
-    "        core.compile_model(ov_image_proj_encoder_path, device.value),\n",
-    "        core.compile_model(ov_controlnet_path, device.value),\n",
-    "        core.compile_model(ov_unet_path, device.value),\n",
-    "        core.compile_model(ov_vae_decoder_path, device.value),\n",
-    "        AutoTokenizer.from_pretrained(MODELS_DIR / \"tokenizer\"),\n",
-    "        AutoTokenizer.from_pretrained(MODELS_DIR / \"tokenizer_2\"),\n",
-    "        LCMScheduler.from_pretrained(MODELS_DIR / \"scheduler\"),\n",
+    "        core.compile_model(text_encoder_path, device.value),\n",
+    "        core.compile_model(text_encoder_2_path, device.value),\n",
+    "        core.compile_model(image_proj_encoder_path, device.value),\n",
+    "        core.compile_model(controlnet_path, device.value),\n",
+    "        core.compile_model(unet_path, device.value),\n",
+    "        core.compile_model(vae_decoder_path, device.value),\n",
+    "        AutoTokenizer.from_pretrained(tokenizer_path),\n",
+    "        AutoTokenizer.from_pretrained(tokenizer_2_path),\n",
+    "        LCMScheduler.from_pretrained(scheduler_path),\n",
     "    )\n",
     "\n",
     "\n",
-    "ov_pipe = create_ov_pipe()"
+    "ov_pipe = create_ov_pipe(\n",
+    "    ov_text_encoder_path,\n",
+    "    ov_text_encoder_2_path,\n",
+    "    ov_image_proj_encoder_path,\n",
+    "    ov_controlnet_path,\n",
+    "    ov_unet_path,\n",
+    "    ov_vae_decoder_path,\n",
+    "    MODELS_DIR / \"tokenizer\",\n",
+    "    MODELS_DIR / \"tokenizer_2\",\n",
+    "    MODELS_DIR / \"scheduler\",\n",
+    ")"
    ]
   },
   {
@@ -2238,7 +2258,7 @@
     "%%skip not $to_quantize.value\n",
     "\n",
     "# Delete loaded full precision pipeline before quantization to lower peak memory footprint.\n",
-    "del ov_pipe\n",
+    "ov_pipe = None\n",
     "gc.collect()"
    ],
    "id": "af9de11ca348fd83"
@@ -4408,27 +4428,16 @@
    "source": [
     "%%skip not $to_quantize.value\n",
     "\n",
-    "optimized_controlnet = core.compile_model(ov_int8_controlnet_path, device.value)\n",
-    "optimized_unet = core.compile_model(ov_int8_unet_path, device.value)\n",
-    "optimized_text_encoder = core.compile_model(ov_int8_text_encoder_path, device.value)\n",
-    "optimized_text_encoder_2 = core.compile_model(ov_int8_text_encoder_2_path, device.value)\n",
-    "optimized_vae_decoder = core.compile_model(ov_int8_vae_decoder_path, device.value)\n",
-    "\n",
-    "image_proj_model = core.compile_model(ov_image_proj_encoder_path, device.value)\n",
-    "tokenizer = AutoTokenizer.from_pretrained(MODELS_DIR / \"tokenizer\")\n",
-    "tokenizer_2 = AutoTokenizer.from_pretrained(MODELS_DIR / \"tokenizer_2\")\n",
-    "scheduler = LCMScheduler.from_pretrained(MODELS_DIR / \"scheduler\")\n",
-    "\n",
-    "int8_pipe = OVStableDiffusionXLInstantIDPipeline(\n",
-    "    optimized_text_encoder,\n",
-    "    optimized_text_encoder_2,\n",
-    "    image_proj_model,\n",
-    "    optimized_controlnet,\n",
-    "    optimized_unet,\n",
-    "    optimized_vae_decoder,\n",
-    "    tokenizer,\n",
-    "    tokenizer_2,\n",
-    "    scheduler,\n",
+    "int8_pipe = create_ov_pipe(\n",
+    "    ov_int8_text_encoder_path,\n",
+    "    ov_int8_text_encoder_2_path,\n",
+    "    ov_image_proj_encoder_path,\n",
+    "    ov_int8_controlnet_path,\n",
+    "    ov_int8_unet_path,\n",
+    "    ov_int8_vae_decoder_path,\n",
+    "    MODELS_DIR / \"tokenizer\",\n",
+    "    MODELS_DIR / \"tokenizer_2\",\n",
+    "    MODELS_DIR / \"scheduler\"\n",
     ")"
    ]
   },
@@ -4653,7 +4662,17 @@
     "%%skip (not $to_quantize.value or not $run_inference_time_comparison.value)\n",
     "\n",
     "# Load full precision pipeline\n",
-    "ov_pipe = create_ov_pipe()"
+    "ov_pipe = create_ov_pipe(\n",
+    "    ov_text_encoder_path,\n",
+    "    ov_text_encoder_2_path,\n",
+    "    ov_image_proj_encoder_path,\n",
+    "    ov_controlnet_path,\n",
+    "    ov_unet_path,\n",
+    "    ov_vae_decoder_path,\n",
+    "    MODELS_DIR / \"tokenizer\",\n",
+    "    MODELS_DIR / \"tokenizer_2\",\n",
+    "    MODELS_DIR / \"scheduler\",\n",
+    ")"
    ],
    "id": "1ab19a417e7cd264"
   },
@@ -4742,7 +4761,17 @@
     "        del ov_pipe\n",
     "        gc.collect()\n",
     "elif ov_pipe is None:\n",
-    "    ov_pipe = create_ov_pipe()"
+    "    ov_pipe = create_ov_pipe(\n",
+    "        ov_text_encoder_path,\n",
+    "        ov_text_encoder_2_path,\n",
+    "        ov_image_proj_encoder_path,\n",
+    "        ov_controlnet_path,\n",
+    "        ov_unet_path,\n",
+    "        ov_vae_decoder_path,\n",
+    "        MODELS_DIR / \"tokenizer\",\n",
+    "        MODELS_DIR / \"tokenizer_2\",\n",
+    "        MODELS_DIR / \"scheduler\",\n",
+    "    )"
    ],
    "id": "728fb893f25d854f"
   },
@@ -5050,7 +5079,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Statistics collection <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">200/200</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:14:43</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Statistics collection \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m200/200\u001b[0m • \u001b[38;2;0;104;181m0:14:43\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Statistics collection \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m200/200\u001B[0m • \u001B[38;2;0;104;181m0:14:43\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5096,7 +5125,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Weight Compression <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">40/40</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Weight Compression \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m40/40\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Weight Compression \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m40/40\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5165,7 +5194,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Fast Bias correction <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">197/197</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:41</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Fast Bias correction \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m197/197\u001b[0m • \u001b[38;2;0;104;181m0:00:41\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Fast Bias correction \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m197/197\u001B[0m • \u001B[38;2;0;104;181m0:00:41\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5205,7 +5234,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Statistics collection <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">200/200</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:09:21</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Statistics collection \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m200/200\u001b[0m • \u001b[38;2;0;104;181m0:09:21\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Statistics collection \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m200/200\u001B[0m • \u001B[38;2;0;104;181m0:09:21\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5229,7 +5258,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Fast Bias correction <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">51/51</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:17</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Fast Bias correction \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m51/51\u001b[0m • \u001b[38;2;0;104;181m0:00:17\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Fast Bias correction \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m51/51\u001B[0m • \u001B[38;2;0;104;181m0:00:17\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5247,7 +5276,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Weight Compression <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">195/195</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:04</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Weight Compression \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m195/195\u001b[0m • \u001b[38;2;0;104;181m0:00:04\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Weight Compression \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m195/195\u001B[0m • \u001B[38;2;0;104;181m0:00:04\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5265,7 +5294,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Smooth Quant <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">220/220</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:20</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Smooth Quant \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m220/220\u001b[0m • \u001b[38;2;0;104;181m0:00:20\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Smooth Quant \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m220/220\u001B[0m • \u001B[38;2;0;104;181m0:00:20\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5403,7 +5432,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Weight Compression <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">74/74</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Weight Compression \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m74/74\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Weight Compression \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m74/74\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5489,7 +5518,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Statistics collection <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">200/200</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:04:15</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Statistics collection \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m200/200\u001b[0m • \u001b[38;2;0;104;181m0:04:15\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Statistics collection \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m200/200\u001B[0m • \u001B[38;2;0;104;181m0:04:15\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -5565,7 +5594,7 @@
         {
          "data": {
           "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Applying Weight Compression <span style=\"color: #729c1f; text-decoration-color: #729c1f\">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> <span style=\"color: #0068b5; text-decoration-color: #0068b5\">883/883</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:17</span> • <span style=\"color: #0068b5; text-decoration-color: #0068b5\">0:00:00</span>\n</pre>\n",
-          "text/plain": "Applying Weight Compression \u001b[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[35m100%\u001b[0m \u001b[38;2;0;104;181m883/883\u001b[0m • \u001b[38;2;0;104;181m0:00:17\u001b[0m • \u001b[38;2;0;104;181m0:00:00\u001b[0m\n"
+          "text/plain": "Applying Weight Compression \u001B[38;2;114;156;31m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[35m100%\u001B[0m \u001B[38;2;0;104;181m883/883\u001B[0m • \u001B[38;2;0;104;181m0:00:17\u001B[0m • \u001B[38;2;0;104;181m0:00:00\u001B[0m\n"
          },
          "metadata": {},
          "output_type": "display_data"


### PR DESCRIPTION
**Changes**:
- In order to reduce peak memory footprint, full precision OV pipeline is now deleted right after calibration dataset is collected. This way it does not take up additional memory during quantization.
- Comparing inference speed of original and optimized pipelines is now optional (disabled by default) for the same reason.

After applying the changes and updating to openvino-nightly, the peak memory is observed to drop from 120 GB to 60 GB.

Related ticket: 146016