### PR TITLE
missing model parameter

### DIFF
--- a/notebooks/yolov11-optimization/yolov11-keypoint-detection.ipynb
+++ b/notebooks/yolov11-optimization/yolov11-keypoint-detection.ipynb
@@ -899,7 +899,7 @@
     "%%skip not $to_quantize.value\n",
     "\n",
     "if quantized_pose_model is None:\n",
-    "    quantized_pose_model = core.read_model()\n",
+    "    quantized_pose_model = core.read_model(int8_model_pose_path)\n",
     "\n",
     "ov_config = {}\n",
     "if device.value != \"CPU\":\n",


### PR DESCRIPTION
A quick patch to the missing model parameter. This bug got triggered usually only after the second run. 