### PR TITLE
Delete unused variable to fix CI error

### DIFF
--- a/notebooks/bark-text-to-audio/bark-text-to-audio.ipynb
+++ b/notebooks/bark-text-to-audio/bark-text-to-audio.ipynb
@@ -671,7 +671,6 @@
     "        semantic_history = None\n",
     "    encoded_text = np.ascontiguousarray(_tokenize(tokenizer, text)) + TEXT_ENCODING_OFFSET\n",
     "    if len(encoded_text) > 256:\n",
-    "        p = round((len(encoded_text) - 256) / len(encoded_text) * 100, 1)\n",
     "        encoded_text = encoded_text[:256]\n",
     "    encoded_text = np.pad(\n",
     "        encoded_text,\n",


### PR DESCRIPTION
It used only for warning that we don't use: https://github.com/suno-ai/bark/blob/main/bark/generation.py#L418