### PR TITLE
Uninstall tesorflow and tensorflow-macos in test environments

### DIFF
--- a/notebooks/tensorflow-quantization-aware-training/tensorflow-quantization-aware-training.ipynb
+++ b/notebooks/tensorflow-quantization-aware-training/tensorflow-quantization-aware-training.ipynb
@@ -69,15 +69,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "319bffad",
-   "metadata": {},
+   "metadata": {
+    "test_replace": {
+     "%pip install -q \"tensorflow-macos>=2.9.3,<2.16.0; sys_platform == 'darwin' and platform_machine == 'arm64'\"\n": "import platform; if platform.system() == 'Darwin' and platform.processor() in ('arm', 'arm64'): %pip uninstall -qy tensorflow \"tensorflow-macos\"; %pip install -q \"tensorflow-macos>=2.9.3,<2.16.0; sys_platform == 'darwin' and platform_machine == 'arm64'\"\n"
+    }
+   },
    "outputs": [],
    "source": [
-    "import platform\n",
-    "\n",
-    "\n",
-    "if platform.system() == \"Darwin\" and platform.processor() in (\"arm\", \"arm64\"):\n",
-    "    %pip uninstall -qy tensorflow\n",
-    "\n",
     "%pip install -q \"openvino>=2024.6.0\" \"nncf>=2.14.0\"\n",
     "%pip install -q \"tensorflow-macos>=2.9.3,<2.16.0; sys_platform == 'darwin' and platform_machine == 'arm64'\"\n",
     "%pip install -q \"tensorflow>=2.9.3,<2.16.0; sys_platform == 'darwin' and platform_machine != 'arm64'\" # macOS x86\n",

--- a/notebooks/tensorflow-quantization-aware-training/tensorflow-quantization-aware-training.ipynb
+++ b/notebooks/tensorflow-quantization-aware-training/tensorflow-quantization-aware-training.ipynb
@@ -71,7 +71,7 @@
    "id": "319bffad",
    "metadata": {
     "test_replace": {
-     "%pip install -q \"tensorflow-macos>=2.9.3,<2.16.0; sys_platform == 'darwin' and platform_machine == 'arm64'\"\n": "import platform; if platform.system() == 'Darwin' and platform.processor() in ('arm', 'arm64'): %pip uninstall -qy tensorflow \"tensorflow-macos\"; %pip install -q \"tensorflow-macos>=2.9.3,<2.16.0; sys_platform == 'darwin' and platform_machine == 'arm64'\"\n"
+     "%pip install -q \"tensorflow-macos>=2.9.3,<2.16.0; sys_platform == 'darwin' and platform_machine == 'arm64'\"\n": "import platform\nif platform.system() == 'Darwin' and platform.processor() in ('arm', 'arm64'):\n    %pip uninstall -qy tensorflow tensorflow-macos\n%pip install -q \"tensorflow-macos>=2.9.3,<2.16.0; sys_platform == 'darwin' and platform_machine == 'arm64'\"\n"
     }
    },
    "outputs": [],


### PR DESCRIPTION
CVS-163492

Looks like uninstallation only tesnorflow on macos in the case tensorflow-macos is installed too breaks installed library. Uninstallation of both in test environment and install only tensorflow-macos should resolve the problem.