### PR TITLE
Download 'people.mp4' file when it does not exist.

### DIFF
--- a/notebooks/yolov11-optimization/yolov11-instance-segmentation.ipynb
+++ b/notebooks/yolov11-optimization/yolov11-instance-segmentation.ipynb
@@ -1200,7 +1200,7 @@
     "    VIDEO_SOURCE = 0  # Webcam\n",
     "else:\n",
     "    VIDEO_SOURCE = Path(\"people.mp4\")\n",
-    "    if VIDEO_SOURCE.exists():\n",
+    "    if not VIDEO_SOURCE.exists():\n",
     "        download_file(\n",
     "            \"https://storage.openvinotoolkit.org/repositories/openvino_notebooks/data/data/video/people.mp4\",\n",
     "            \"people.mp4\",\n",


### PR DESCRIPTION
The 'if' statement condition to download the movie file is reversed. Added a 'not' to fix it.
