### PR TITLE
Enable legacy nncf tracing for pytorch-quantization-sparsity-aware-training

### DIFF
--- a/notebooks/pytorch-quantization-sparsity-aware-training/pytorch-quantization-sparsity-aware-training.ipynb
+++ b/notebooks/pytorch-quantization-sparsity-aware-training/pytorch-quantization-sparsity-aware-training.ipynb
@@ -62,8 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q --extra-index-url https://download.pytorch.org/whl/cpu  \"openvino>=2024.0.0\" \"torch\" \"torchvision\" \"tqdm\"\n",
-    "%pip install -q \"nncf>=2.9.0\""
+    "%pip install -q --extra-index-url https://download.pytorch.org/whl/cpu  \"openvino>=2024.0.0\" \"torch\" \"torchvision\" \"tqdm\" \"nncf>=2.9.0\""
    ]
   },
   {

--- a/notebooks/pytorch-quantization-sparsity-aware-training/pytorch-quantization-sparsity-aware-training.ipynb
+++ b/notebooks/pytorch-quantization-sparsity-aware-training/pytorch-quantization-sparsity-aware-training.ipynb
@@ -538,6 +538,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"NNCF_TORCH_LEGACY_TRACING\"] = \"1\"\n",
     "from nncf import NNCFConfig\n",
     "from nncf.torch import create_compressed_model, register_default_init_args\n",
     "\n",

--- a/notebooks/pytorch-quantization-sparsity-aware-training/pytorch-quantization-sparsity-aware-training.ipynb
+++ b/notebooks/pytorch-quantization-sparsity-aware-training/pytorch-quantization-sparsity-aware-training.ipynb
@@ -540,7 +540,8 @@
    "source": [
     "import os\n",
     "\n",
-    "os.environ[\"NNCF_TORCH_LEGACY_TRACING\"] = \"1\"\n",
+    "# os.environ[\"NNCF_TORCH_LEGACY_TRACING\"] = \"1\"\n",
+    "\n",
     "from nncf import NNCFConfig\n",
     "from nncf.torch import create_compressed_model, register_default_init_args\n",
     "\n",

--- a/notebooks/pytorch-quantization-sparsity-aware-training/pytorch-quantization-sparsity-aware-training.ipynb
+++ b/notebooks/pytorch-quantization-sparsity-aware-training/pytorch-quantization-sparsity-aware-training.ipynb
@@ -540,8 +540,7 @@
    "source": [
     "import os\n",
     "\n",
-    "# os.environ[\"NNCF_TORCH_LEGACY_TRACING\"] = \"1\"\n",
-    "\n",
+    "os.environ[\"NNCF_TORCH_LEGACY_TRACING\"] = \"1\"\n",
     "from nncf import NNCFConfig\n",
     "from nncf.torch import create_compressed_model, register_default_init_args\n",
     "\n",

--- a/notebooks/pytorch-quantization-sparsity-aware-training/pytorch-quantization-sparsity-aware-training.ipynb
+++ b/notebooks/pytorch-quantization-sparsity-aware-training/pytorch-quantization-sparsity-aware-training.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q --extra-index-url https://download.pytorch.org/whl/cpu  \"openvino>=2024.0.0\" \"torch\" \"torchvision\" \"tqdm\" \"nncf>=2.9.0\""
+    "%pip install -q --extra-index-url https://download.pytorch.org/whl/cpu  \"openvino>=2024.0.0\" \"torch\" \"torchvision\" \"tqdm\" \"nncf>=2.9.0\" \"numpy<2; sys_platform == 'darwin'\""
    ]
   },
   {


### PR DESCRIPTION
166057