### PR TITLE
Fix model download issue: Download both .xml and .bin files

### DIFF
--- a/notebooks/person-tracking-webcam/person-tracking.ipynb
+++ b/notebooks/person-tracking-webcam/person-tracking.ipynb
@@ -172,23 +172,34 @@
     "# A directory where the model will be downloaded.\n",
     "base_model_dir = \"model\"\n",
     "precision = \"FP16\"\n",
+    "\n",
     "# The name of the model from Open Model Zoo\n",
     "detection_model_name = \"person-detection-0202\"\n",
-    "download_det_model_url = (\n",
-    "    f\"https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/{detection_model_name}/{precision}/{detection_model_name}.xml\"\n",
-    ")\n",
     "detection_model_path = Path(base_model_dir) / detection_model_name / precision / f\"{detection_model_name}.xml\"\n",
+    "detection_model_bin_path = Path(base_model_dir) / detection_model_name / precision / f\"{detection_model_name}.bin\"\n",
     "\n",
+    "# Download both .xml and .bin files for detection model\n",
     "if not detection_model_path.exists():\n",
+    "    download_det_model_xml_url = f\"https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/{detection_model_name}/{precision}/{detection_model_name}.xml\"\n",
+    "    download_ir_model(download_det_model_xml_url, Path(base_model_dir) / detection_model_name / precision)\n",
     "\n",
-    "    download_ir_model(download_det_model_url, Path(base_model_dir) / detection_model_name / precision)\n",
+    "if not detection_model_bin_path.exists():\n",
+    "    download_det_model_bin_url = f\"https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/{detection_model_name}/{precision}/{detection_model_name}.bin\"\n",
+    "    download_ir_model(download_det_model_bin_url, Path(base_model_dir) / detection_model_name / precision)\n",
     "\n",
+    "# The reidentification model\n",
     "reidentification_model_name = \"person-reidentification-retail-0287\"\n",
-    "download_reid_model_url = f\"https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/{reidentification_model_name}/{precision}/{reidentification_model_name}.xml\"\n",
     "reidentification_model_path = Path(base_model_dir) / reidentification_model_name / precision / f\"{reidentification_model_name}.xml\"\n",
+    "reidentification_model_bin_path = Path(base_model_dir) / reidentification_model_name / precision / f\"{reidentification_model_name}.bin\"\n",
     "\n",
+    "# Download both .xml and .bin files for reidentification model\n",
     "if not reidentification_model_path.exists():\n",
-    "    download_ir_model(download_reid_model_url, Path(base_model_dir) / reidentification_model_name / precision)"
+    "    download_reid_model_xml_url = f\"https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/{reidentification_model_name}/{precision}/{reidentification_model_name}.xml\"\n",
+    "    download_ir_model(download_reid_model_xml_url, Path(base_model_dir) / reidentification_model_name / precision)\n",
+    "\n",
+    "if not reidentification_model_bin_path.exists():\n",
+    "    download_reid_model_bin_url = f\"https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/{reidentification_model_name}/{precision}/{reidentification_model_name}.bin\"\n",
+    "    download_ir_model(download_reid_model_bin_url, Path(base_model_dir) / reidentification_model_name / precision)"
    ]
   },
   {
@@ -723,7 +734,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "openvino_env",
    "language": "python",
    "name": "python3"
   },
@@ -737,7 +748,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.12.7"
   },
   "openvino_notebooks": {
    "imageUrl": "https://github.com/openvinotoolkit/openvino_notebooks/blob/latest/notebooks/person-tracking-webcam/person-tracking.gif?raw=true",
@@ -750,11 +761,6 @@
     "tasks": [
      "Object Detection"
     ]
-   }
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "1c707170576399eaaed0c4f2e01a2d1b61ba791ba1842c47e5b3e4f6f79b82ab"
    }
   },
   "widgets": {


### PR DESCRIPTION
## Fix model download and execution issues for person detection and re-identification

### What changed

This PR addresses an issue where the model downloader was only fetching the `.xml` (model architecture) file but not the corresponding `.bin` (model weights) file for OpenVINO models. This mismatch caused runtime errors like:

### Why this was needed

Both the `.xml` and `.bin` files are required for OpenVINO IR (Intermediate Representation) models to run inference. Without the weights file, the model can't load or perform any predictions. Users trying to run the **person detection** (`person-detection-0202`) or **person re-identification** (`person-reidentification-retail-0287`) pipelines were hitting this error.

### What models are impacted

- **person-detection-0202**
- **person-reidentification-retail-0287**

These models are often used together for multi-step pipelines (e.g., detect a person, then re-identify them across frames or cameras).

### What I did

- Updated the download logic to ensure **both** the `.xml` and `.bin` files for each model are downloaded and available at runtime.
- Ran end-to-end tests on both models to confirm they load successfully and perform inference without errors.
- Cleaned up leftover cell outputs in the notebook for readability and to prevent confusion when users open the notebook.

### How to test

1. Run the notebook end-to-end.
2. Confirm that both models load without errors.
3. Check that both `.xml` and `.bin` files exist in the expected download directory.

### Before this fix:

Running inference would fail with missing weights error.

### After this fix:

Both models load successfully and inference runs as expected.

---