### PR TITLE
Replace validation dataset on the same in parquet format

### DIFF
--- a/notebooks/named-entity-recognition/named-entity-recognition.ipynb
+++ b/notebooks/named-entity-recognition/named-entity-recognition.ipynb
@@ -297,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "test_replace": {
      "num_samples=100,": "num_samples=10,"
@@ -518,7 +518,7 @@
     "if not quantized_ner_model_dir.exists():\n",
     "    quantizer = OVQuantizer.from_pretrained(model)\n",
     "    calibration_dataset = quantizer.get_calibration_dataset(\n",
-    "        \"conll2003\",\n",
+    "        \"tner/conll2003\",\n",
     "        preprocess_function=partial(preprocess_fn, tokenizer=tokenizer),\n",
     "        num_samples=100,\n",
     "        dataset_split=\"train\",\n",


### PR DESCRIPTION
CVS-170237
datasets since version 4.0 doesn't allow script files in dataset. Replacing the  validation dataset on the same in parquet format