### PR TITLE
Add commit notebooks index from github-actions[bot], but not default user

### DIFF
--- a/.github/workflows/gh_pages_deploy.yml
+++ b/.github/workflows/gh_pages_deploy.yml
@@ -95,12 +95,14 @@ jobs:
       - name: Commit notebooks index
         if: ${{ steps.check_deploy.outputs.should_deploy == 'true' }}
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACTIONS_BOT_TOKEN }}
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add ./notebooks/README.md
           git commit -m "Update notebooks index readme file [skip ci]" || echo "Index file is not changed"
-          git push
+          git push https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:latest
 
   deploy_github_pages:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
GitHub Pages workflow fails because current default user hasn't access. Now it should be pushed from github-actions[bot]