### PR TITLE
Add missing ipywidgets dependency to InternVL2 notebook

### DIFF
--- a/notebooks/internvl2/internvl2.ipynb
+++ b/notebooks/internvl2/internvl2.ipynb
@@ -106,6 +106,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install ipywidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
## Description
Adds the missing `ipywidgets` package installation to the InternVL2 notebook prerequisites.

## Problem
The notebook uses `ipywidgets` to create a dropdown model selector widget in the "Select model" section, but the package was not being installed in the Prerequisites cell. This caused the widget to fail when users ran the notebook.

## Solution
Added `%pip install ipywidgets` as a dedicated cell in the "Select model" section, immediately before the model selector code that depends on it. This ensures the package is available before it's needed.

## Changes
- Added cell with `%pip install ipywidgets` installation in the InternVL2 notebook

## Testing
The notebook can now successfully run the model selector widget without dependency errors.

## Related Issues
Part of the effort to identify and add missing pip requirements across notebooks.
Below is the screenshot of the issue:
<img width="2512" height="1204" alt="Screenshot 2025-11-13 135526" src="https://github.com/user-attachments/assets/8cea5c91-b44f-41c0-91ec-ea7493ffd50b" />
