### PR TITLE
[GPU] adding ACTIVATIONS_SCALE_FACTOR configs for sana models

### DIFF
--- a/notebooks/sana-image-generation/sana-image-generation.ipynb
+++ b/notebooks/sana-image-generation/sana-image-generation.ipynb
@@ -369,7 +369,12 @@
    "source": [
     "from optimum.intel.openvino import OVDiffusionPipeline\n",
     "\n",
-    "ov_pipe = OVDiffusionPipeline.from_pretrained(model_dir, device=device.value, transformer_file_name=compressed_transformer.name if to_compress.value else None)"
+    "ov_pipe = OVDiffusionPipeline.from_pretrained(model_dir, device=device.value, transformer_file_name=compressed_transformer.name if to_compress.value else None, compile=False)\n",
+    "if \"GPU\" in device.value:\n",
+    "    ov_pipe.transformer.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\" : \"96\"}\n",
+    "    if \"sprint\" not in model_id.lower() and \"1.5\" not in model_id:\n",
+    "        ov_pipe.transformer.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\" : \"384\"}\n",
+    "    ov_pipe.vae_decoder.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\" : \"2560\"}\n",
    ]
   },
   {

--- a/notebooks/sana-image-generation/sana-image-generation.ipynb
+++ b/notebooks/sana-image-generation/sana-image-generation.ipynb
@@ -369,12 +369,14 @@
    "source": [
     "from optimum.intel.openvino import OVDiffusionPipeline\n",
     "\n",
-    "ov_pipe = OVDiffusionPipeline.from_pretrained(model_dir, device=device.value, transformer_file_name=compressed_transformer.name if to_compress.value else None, compile=False)\n",
+    "ov_pipe = OVDiffusionPipeline.from_pretrained(\n",
+    "    model_dir, device=device.value, transformer_file_name=compressed_transformer.name if to_compress.value else None, compile=False\n",
+    ")\n",
     "if \"GPU\" in device.value:\n",
-    "    ov_pipe.transformer.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\" : \"96\"}\n",
+    "    ov_pipe.transformer.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\": \"96\"}\n",
     "    if \"sprint\" not in model_id.lower() and \"1.5\" not in model_id:\n",
-    "        ov_pipe.transformer.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\" : \"384\"}\n",
-    "    ov_pipe.vae_decoder.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\" : \"2560\"}\n"
+    "        ov_pipe.transformer.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\": \"384\"}\n",
+    "    ov_pipe.vae_decoder.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\": \"2560\"}"
    ]
   },
   {

--- a/notebooks/sana-image-generation/sana-image-generation.ipynb
+++ b/notebooks/sana-image-generation/sana-image-generation.ipynb
@@ -374,7 +374,7 @@
     "    ov_pipe.transformer.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\" : \"96\"}\n",
     "    if \"sprint\" not in model_id.lower() and \"1.5\" not in model_id:\n",
     "        ov_pipe.transformer.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\" : \"384\"}\n",
-    "    ov_pipe.vae_decoder.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\" : \"2560\"}\n",
+    "    ov_pipe.vae_decoder.ov_config = {\"ACTIVATIONS_SCALE_FACTOR\" : \"2560\"}\n"
    ]
   },
   {


### PR DESCRIPTION
### Details:
 - This PR adds `ACTIVATIONS_SCALE_FACTOR` for sana models when a GPU device is selected.
   - Currently, OV generates blank images due to overflow when sana models are executed with fp16 precision on GPUs.
   - To prevent this issue, we need to set `ACTIVATIONS_SCALE_FACTOR` with proper values.
 - This PR depends on https://github.com/openvinotoolkit/openvino/pull/33964, and resolves https://github.com/openvinotoolkit/openvino_notebooks/issues/2957

### Tickets:
 - 177311
