### PR TITLE
Fixes TypeError: 'type' object is not subscriptable when importing notebook_utils (issue #3007)

### DIFF
--- a/utils/notebook_utils.py
+++ b/utils/notebook_utils.py
@@ -10,7 +10,7 @@ import threading
 import time
 from os import PathLike
 from pathlib import Path
-from typing import NamedTuple, Optional
+from typing import List, NamedTuple, Optional
 
 
 # ## Files
@@ -496,7 +496,7 @@ def viz_result_image(
     source_image=None,
     source_title: str = None,
     result_title: str = None,
-    labels: list[Label] = None,
+    labels: Optional[List[Label]] = None,
     resize: bool = False,
     bgr_to_rgb: bool = False,
     hide_axes: bool = False,


### PR DESCRIPTION
Root Cause:
The 'list[Label]' type hint requires Python 3.9+. Users on Python 3.8 would encounter this error at import time
Regarding issue#3007, this means that Intel Arc GPU does not cause this issue.

Solution:
Use `typing.List[Label]` instead, which is compatible with Python 3.8+.

Testing:
- No new notebooks added
- Change is in shared `utils/notebook_utils.py` only
- Existing type hints and docstrings preserved

Note: CONTRIBUTING specifies Python 3.10+. This change adds compatibility for users who haven’t upgraded yet
Happy to revert if there is a preference to stay strictly on 3.10+