### PR TITLE
Fix DeepSeek-OCR1 model util notebook

### DIFF
--- a/notebooks/deepseek-ocr/ov_deepseek_ocr_helper.py
+++ b/notebooks/deepseek-ocr/ov_deepseek_ocr_helper.py
@@ -1340,7 +1340,7 @@ class OVDeepseekOCRForCausalLM(GenerationMixin):
                 else:
                     if crop_mode:
                         # best_width, best_height = select_best_resolution(image.size, self.candidate_resolutions)
-                        images_crop_raw, crop_ratio = dynamic_preprocess(image)
+                        images_crop_raw, crop_ratio = dynamic_preprocess(image, image_size=image_size)
                     else:
                         # best_width, best_height = self.image_size, self.image_size
                         crop_ratio = [1, 1]


### PR DESCRIPTION
For DeepSeek-OCR1 the inference fails with error listed at the bottom of PR description. The reason is that without giving `image_size` to `dynamic_preprocess` function it defaults to 640, causing image mask to be inconsistent with the number of entries, ending up with `masked_scatter_` error. After this fix the inference returns correct results.

Ticket: 176124

```bash
RuntimeError                              Traceback (most recent call last)
Cell In[11], line 4
      1 prompt = "<image>\n<|grounding|>Convert the document to markdown. "
      2 output_path = "."
----> 4 res = model.infer(
      5     tokenizer,
      6     prompt=prompt,
      7     image_file=file_name,
      8     output_path=output_path,
      9     base_size=1024,
     10     image_size=768,
     11     crop_mode=True,
     12     save_results=True,
     13     test_compress=True,
     14 )

File ~/openvino_notebooks/notebooks/deepseek-ocr/ov_deepseek_ocr_helper.py:1455, in OVDeepseekOCRForCausalLM.infer(self, tokenizer, prompt, image_file, output_path, base_size, image_size, crop_mode, test_compress, save_results, eval_mode)
   1453     streamer = NoEOSTextStreamer(tokenizer, skip_prompt=True, skip_special_tokens=False)
   1454     with torch.no_grad():
-> 1455         output_ids = self.generate(
   1456             input_ids.unsqueeze(0),
   1457             images=[(images_crop, images_ori)],
   1458             images_seq_mask=images_seq_mask.unsqueeze(0),
   1459             images_spatial_crop=images_spatial_crop,
...
-> 1131         inputs_embeds[idx].masked_scatter_(images_seq_mask[idx].unsqueeze(-1), images_in_this_batch)
   1133     idx += 1
   1135 return inputs_embeds

RuntimeError: Number of elements of source < number of ones in mask
Output is truncated. View as a scrollable element or open in a text editor. Adjust cell output settings...
```