### PR TITLE
fix: replace tqdm.notebook import with tqdm in helper scripts

### DIFF
--- a/notebooks/catvton/catvton_quantization_helper.py
+++ b/notebooks/catvton/catvton_quantization_helper.py
@@ -1,7 +1,7 @@
 from typing import Any
 from pathlib import Path
 
-from tqdm.notebook import tqdm
+from tqdm.auto import tqdm
 from transformers import set_seed
 import numpy as np
 import openvino as ov

--- a/notebooks/ltx-video/ltx_video_quantization_helper.py
+++ b/notebooks/ltx-video/ltx_video_quantization_helper.py
@@ -4,7 +4,7 @@ import numpy as np
 from pathlib import Path
 import openvino as ov
 import torch
-from tqdm.notebook import tqdm
+from tqdm.auto import tqdm
 
 negative_prompts = [
     "blurry unreal occluded",

--- a/notebooks/sam2-image-segmentation/automatic_mask_generation_helper.py
+++ b/notebooks/sam2-image-segmentation/automatic_mask_generation_helper.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import torch
 
-from tqdm.notebook import tqdm
+from tqdm.auto import tqdm
 
 import cv2
 

--- a/notebooks/stable-diffusion-v3-torch-fx/sd3_quantization_helper.py
+++ b/notebooks/stable-diffusion-v3-torch-fx/sd3_quantization_helper.py
@@ -7,7 +7,7 @@ import nncf
 import numpy as np
 import openvino as ov
 import torch
-from tqdm.notebook import tqdm
+from tqdm.auto import tqdm
 from transformers import set_seed
 from sd3_helper import MODEL_DIR, TRANSFORMER_PATH, TEXT_ENCODER_PATH, TEXT_ENCODER_2_PATH, TEXT_ENCODER_3_PATH, VAE_DECODER_PATH, init_pipeline
 


### PR DESCRIPTION
## Summary

Replaces `from tqdm.notebook import tqdm` with `from tqdm import tqdm` 
in 4 helper scripts.

## Problem

`tqdm.notebook` is designed exclusively for Jupyter notebook cells — it 
renders an IPython widget. When the same import is used inside a plain 
`.py` helper script (which gets imported by notebooks, not run as a cell), 
it either falls back silently or raises a rendering warning depending on 
the environment. The correct import for helper scripts is the standard 
`from tqdm import tqdm`, which works correctly in both notebook and 
non-notebook contexts.

## Files Changed

- `notebooks/catvton/catvton_quantization_helper.py`
- `notebooks/ltx-video/ltx_video_quantization_helper.py`  
- `notebooks/sam2-image-segmentation/automatic_mask_generation_helper.py`
- `notebooks/stable-diffusion-v3-torch-fx/sd3_quantization_helper.py`

## Verification
```powershell
Get-ChildItem -Path notebooks/ -Recurse -Include "*.py" |
  Select-String -Pattern "from tqdm\.notebook import tqdm"
```
Output: empty (all fixed)