### PR TITLE
[ACE-Step] Fix torchaudio FFmpeg dependency and gradio 6.x compatibility

### DIFF
--- a/notebooks/ace-step-music-generation/gradio_helper.py
+++ b/notebooks/ace-step-music-generation/gradio_helper.py
@@ -43,9 +43,7 @@ def create_text2music_ui(gr, ov_pipeline, sample_data_func=None, lora_path=None)
                     label="Enable Audio2Audio", value=False, info="Enable Audio-to-Audio generation using a reference audio.", elem_id="audio2audio_checkbox"
                 )
 
-            ref_audio_input = gr.Audio(
-                type="filepath", label="Reference Audio (for Audio2Audio task)", visible=False, elem_id="ref_audio_input", show_download_button=True
-            )
+            ref_audio_input = gr.Audio(type="filepath", label="Reference Audio (for Audio2Audio task)", visible=False, elem_id="ref_audio_input")
             ref_audio_strength = gr.Slider(
                 label="Refer audio strength",
                 minimum=0.0,
@@ -290,7 +288,6 @@ def create_text2music_ui(gr, ov_pipeline, sample_data_func=None, lora_path=None)
                     type="filepath",
                     visible=False,
                     elem_id="repaint_source_audio_upload",
-                    show_download_button=True,
                 )
                 repaint_source.change(
                     fn=lambda x: gr.update(visible=x == "upload", elem_id="repaint_source_audio_upload"),
@@ -450,7 +447,6 @@ def create_text2music_ui(gr, ov_pipeline, sample_data_func=None, lora_path=None)
                     type="filepath",
                     visible=False,
                     elem_id="edit_source_audio_upload",
-                    show_download_button=True,
                 )
                 edit_source.change(
                     fn=lambda x: gr.update(visible=x == "upload", elem_id="edit_source_audio_upload"),
@@ -593,7 +589,6 @@ def create_text2music_ui(gr, ov_pipeline, sample_data_func=None, lora_path=None)
                     type="filepath",
                     visible=False,
                     elem_id="extend_source_audio_upload",
-                    show_download_button=True,
                 )
                 extend_source.change(
                     fn=lambda x: gr.update(visible=x == "upload", elem_id="extend_source_audio_upload"),

--- a/notebooks/ace-step-music-generation/ov_ace_helper.py
+++ b/notebooks/ace-step-music-generation/ov_ace_helper.py
@@ -28,6 +28,37 @@ from acestep.music_dcae.music_dcae_pipeline import MusicDCAE
 from acestep.schedulers.scheduling_flow_match_heun_discrete import FlowMatchHeunDiscreteScheduler
 from acestep.schedulers.scheduling_flow_match_pingpong import FlowMatchPingPongScheduler
 from acestep.schedulers.scheduling_flow_match_euler_discrete import FlowMatchEulerDiscreteScheduler
+
+# torchaudio 2.10 delegates load/save to torchcodec, which requires FFmpeg shared
+# libraries (libavutil.so.*, libavcodec.so.*, ...). If they are not available,
+# fall back to the `soundfile` backend which is sufficient for WAV I/O used here.
+try:
+    import torchcodec.decoders  # noqa: F401
+    import torchcodec.encoders  # noqa: F401
+except Exception:
+    import soundfile as sf
+
+    def _save(uri, src, sample_rate, channels_first=True, **_):
+        data = src.numpy()
+        if channels_first and data.ndim > 1:
+            data = data.T
+        sf.write(str(uri), data, sample_rate)
+
+    def _load(uri, frame_offset=0, num_frames=-1, normalize=True, channels_first=True, **_):
+        data, sr = sf.read(
+            str(uri),
+            start=frame_offset,
+            frames=num_frames if num_frames > 0 else -1,
+            dtype="float32" if normalize else "int16",
+            always_2d=True,
+        )
+        tensor = torch.from_numpy(data)
+        return (tensor.T if channels_first else tensor), sr
+
+    torchaudio.save = _save
+    torchaudio.load = _load
+    print("FFmpeg shared libraries not found; using `soundfile` backend for audio I/O.")
+
 from acestep.apg_guidance import (
     apg_forward,
     MomentumBuffer,


### PR DESCRIPTION
Ticket: 185751

Fixes notebook failures on systems without system FFmpeg (torchaudio 2.10 routes save/load through torchcodec) by adding a soundfile fallback in ov_ace_helper.py, imported early so it applies before the PyTorch pipeline runs. Also drops the unused torchcodec install and removes the show_download_button argument that was deleted in gradio 6.x.