### PR TITLE
Restrict diffusers<0.38.0 in notebooks that have pinned transformers

### DIFF
--- a/notebooks/flex.2-image-generation/flex.2-image-generation.ipynb
+++ b/notebooks/flex.2-image-generation/flex.2-image-generation.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "import platform\n",
     "\n",
-    "%pip install -q \"transformers==4.53.3\" \"diffusers>=0.33.0<0.38.0\" \"gradio>=5.30,<6\" \"torch==2.8\" \"torchvision==0.23.0\" \"pillow\" \"sentencepiece\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
+    "%pip install -q \"transformers==4.53.3\" \"diffusers>=0.33.0,<0.38.0\" \"gradio>=5.30,<6\" \"torch==2.8\" \"torchvision==0.23.0\" \"pillow\" \"sentencepiece\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install -q \"git+https://github.com/huggingface/optimum-intel.git\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install -q --pre -U \"openvino>=2025.1.0\" \"nncf>=2.16.0\" --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly\n",
     "\n",

--- a/notebooks/flex.2-image-generation/flex.2-image-generation.ipynb
+++ b/notebooks/flex.2-image-generation/flex.2-image-generation.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "import platform\n",
     "\n",
-    "%pip install -q \"transformers==4.53.3\" \"diffusers>=0.33.0\" \"gradio>=5.30,<6\" \"torch==2.8\" \"torchvision==0.23.0\" \"pillow\" \"sentencepiece\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
+    "%pip install -q \"transformers==4.53.3\" \"diffusers>=0.33.0<0.38.0\" \"gradio>=5.30,<6\" \"torch==2.8\" \"torchvision==0.23.0\" \"pillow\" \"sentencepiece\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install -q \"git+https://github.com/huggingface/optimum-intel.git\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install -q --pre -U \"openvino>=2025.1.0\" \"nncf>=2.16.0\" --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly\n",
     "\n",

--- a/notebooks/flux-fill/flux-fill.ipynb
+++ b/notebooks/flux-fill/flux-fill.ipynb
@@ -72,7 +72,7 @@
     "        with Path(utility_file).open(\"w\") as f:\n",
     "            f.write(r.text)\n",
     "\n",
-    "%pip install -qU \"gradio>=4.19,<6\" \"torch==2.8\" \"transformers==4.53.3\" \"diffusers>=0.32.0\" \"opencv-python\" \"pillow\" \"peft>=0.15.0\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
+    "%pip install -qU \"gradio>=4.19,<6\" \"torch==2.8\" \"transformers==4.53.3\" \"diffusers>=0.32.0,<0.38.0\" \"opencv-python\" \"pillow\" \"peft>=0.15.0\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install -q \"sentencepiece\" \"protobuf\"\n",
     "%pip install -q \"git+https://github.com/huggingface/optimum-intel.git\" \"nncf>=2.16.0\"  --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install -qU --pre \"openvino>=2025.4.0\" \"openvino-genai>=2025.4\" \"openvino-tokenizers\" --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly\n",

--- a/notebooks/flux.1-image-generation/flux.1-image-generation.ipynb
+++ b/notebooks/flux.1-image-generation/flux.1-image-generation.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "import platform\n",
     "\n",
-    "%pip install -q \"gradio>=4.19,<6\" \"torch==2.8\" \"transformers==4.53.3\" \"nncf>=2.15.0\" \"diffusers>=0.31.0\" \"opencv-python\" \"pillow\" \"peft>=0.15.0\" \"optimum\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
+    "%pip install -q \"gradio>=4.19,<6\" \"torch==2.8\" \"transformers==4.53.3\" \"nncf>=2.15.0\" \"diffusers>=0.31.0,<0.38.0\" \"opencv-python\" \"pillow\" \"peft>=0.15.0\" \"optimum\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install -q \"sentencepiece\" \"protobuf\"\n",
     "%pip install -q \"git+https://github.com/huggingface/optimum-intel.git\"\n",
     "%pip install -qU \"openvino>=2025.4.0\" \"openvino_genai>=2025.4\" \"openvino_tokenizers>=2025.4\"\n",

--- a/notebooks/flux.1-kontext/flux.1-kontext.ipynb
+++ b/notebooks/flux.1-kontext/flux.1-kontext.ipynb
@@ -103,7 +103,7 @@
     "    \"https://download.pytorch.org/whl/cpu\",\n",
     ")\n",
     "pip_install(\"-q\", \"sentencepiece\", \"protobuf\")\n",
-    "pip_install(\"-q\", \"diffusers>=0.35.0\")\n",
+    "pip_install(\"-q\", \"diffusers>=0.35.0,<0.38.0\")\n",
     "pip_install(\"-q\", \"git+https://github.com/openvino-dev-samples/optimum-intel.git@kontext\")\n",
     "pip_install(\"-qU\", \"openvino>=2025.2\", \"openvino_genai>=2025.2\", \"openvino_tokenizers>=2025.2\")\n",
     "\n",

--- a/notebooks/inpainting-genai/inpainting-genai.ipynb
+++ b/notebooks/inpainting-genai/inpainting-genai.ipynb
@@ -78,7 +78,7 @@
     "\n",
     "%pip install -q \"git+https://github.com/huggingface/optimum-intel.git\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install -qU --pre \"openvino>=2025.4\" \"openvino-tokenizers>=2025.4\" \"openvino-genai>=2025.4\" \"nncf>=2.19.0\" --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly\n",
-    "%pip install -qU Pillow \"diffusers>=0.30.3\" \"gradio>=4.19,<6\" \"pydantic<2.11.0\" \"typing_extensions>=4.9\" \"tqdm\" \"huggingface-hub\" \"transformers==4.55\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
+    "%pip install -qU Pillow \"diffusers>=0.30.3,<0.38.0\" \"gradio>=4.19,<6\" \"pydantic<2.11.0\" \"typing_extensions>=4.9\" \"tqdm\" \"huggingface-hub\" \"transformers==4.55\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "\n",
     "if platform.system() == \"Darwin\":\n",
     "    %pip install -q \"numpy<2.0.0\"\n",

--- a/notebooks/latent-consistency-models-image-generation/latent-consistency-models-image-generation.ipynb
+++ b/notebooks/latent-consistency-models-image-generation/latent-consistency-models-image-generation.ipynb
@@ -63,7 +63,7 @@
     "%pip uninstall -q -y optimum optimum-intel optimum-onnx\n",
     "\n",
     "%pip install -q \"torch==2.8\" --index-url https://download.pytorch.org/whl/cpu\n",
-    "%pip install -q \"transformers==4.53.3\" tqdm accelerate \"diffusers>=0.30.1\" pillow \"gradio>=4.19,<6\" \"nncf>=2.12.0\" \"datasets>=2.14.6,<4.0.0\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
+    "%pip install -q \"transformers==4.53.3\" tqdm accelerate \"diffusers>=0.30.1,<0.38.0\" pillow \"gradio>=4.19,<6\" \"nncf>=2.12.0\" \"datasets>=2.14.6,<4.0.0\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install -q \"git+https://github.com/huggingface/optimum-intel.git\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install -qU \"openvino>=2025.3\" \"openvino-tokenizers==2025.3\" \"openvino-genai==2025.3\""
    ]

--- a/notebooks/multilora-image-generation/multilora-image-generation.ipynb
+++ b/notebooks/multilora-image-generation/multilora-image-generation.ipynb
@@ -53,7 +53,7 @@
    "source": [
     "import platform\n",
     "\n",
-    "%pip install -q --extra-index-url https://download.pytorch.org/whl/cpu \"torch==2.8\" \"torchvision==0.23.0\" \"transformers==4.53.3\" accelerate \"diffusers>0.25.0\" pillow \"gradio>=4.19\" \"peft>=0.15.0\"\n",
+    "%pip install -q --extra-index-url https://download.pytorch.org/whl/cpu \"torch==2.8\" \"torchvision==0.23.0\" \"transformers==4.53.3\" accelerate \"diffusers>0.25.0,<0.38.0\" pillow \"gradio>=4.19\" \"peft>=0.15.0\"\n",
     "%pip install -q \"git+https://github.com/huggingface/optimum-intel.git\"\n",
     "%pip install -q -U \"openvino>=2024.5.0\" \"openvino-tokenizers>=2024.5.0\" \"openvino-genai>=2024.5.0\"\n",
     "\n",

--- a/notebooks/smoldocling/smoldocling.ipynb
+++ b/notebooks/smoldocling/smoldocling.ipynb
@@ -77,7 +77,7 @@
     "%pip uninstall -q -y optimum optimum-intel optimum-onnx\n",
     "%pip install -q \"torch==2.8\" \"torchvision==0.23.0\" \"Pillow\" \"gradio>=4.36\" \"opencv-python\" \"docling_core\" \"num2words\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install  -q -U \"openvino>=2025.0.0\" \"openvino-tokenizers>=2025.0.0\" \"nncf>=2.15.0\"\n",
-    "%pip install -q \"git+https://github.com/huggingface/optimum-intel.git\" \"transformers==4.53.3\" \"diffusers>=0.29.0\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
+    "%pip install -q \"git+https://github.com/huggingface/optimum-intel.git\" \"transformers==4.53.3\" \"diffusers>=0.29.0,<0.38.0\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "\n",
     "if platform.system() == \"Darwin\":\n",
     "    %pip install -q \"numpy<2.0\""

--- a/notebooks/smolvlm2/smolvlm2.ipynb
+++ b/notebooks/smolvlm2/smolvlm2.ipynb
@@ -64,7 +64,7 @@
     "%pip install -q \"torch==2.8\" \"torchvision==0.23.0\" \"Pillow\" \"gradio>=4.36\" \"opencv-python\" \"num2words\" \"av\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install  -q -U \"openvino>=2025.0.0\" \"openvino-tokenizers>=2025.0.0\" \"nncf>=2.15.0\"\n",
     "%pip install -q \"git+https://github.com/huggingface/optimum-intel.git\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
-    "%pip install -q \"transformers==4.53.3\" \"diffusers>=0.29.0\" \"accelerate\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
+    "%pip install -q \"transformers==4.53.3\" \"diffusers>=0.29.0,<0.38.0\" \"accelerate\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "\n",
     "if platform.system() == \"Darwin\":\n",
     "    %pip install -q \"numpy<2.0\""

--- a/notebooks/stable-diffusion-v2-infinite-zoom/stable-diffusion-v2-infinite-zoom.ipynb
+++ b/notebooks/stable-diffusion-v2-infinite-zoom/stable-diffusion-v2-infinite-zoom.ipynb
@@ -105,7 +105,7 @@
    "source": [
     "%pip uninstall -q -y optimum optimum-intel optimum-onnx\n",
     "%pip install -q -U \"openvino>=2025.0\" \"openvino-genai>=2025.0\"\n",
-    "%pip install -q \"diffusers>=0.14.0\" \"transformers==4.53.3\" \"gradio>=4.19\" \"torch==2.8\" \"torchvision==0.23.0\" Pillow opencv-python \"git+https://github.com/huggingface/optimum-intel.git\" --extra-index-url https://download.pytorch.org/whl/cpu"
+    "%pip install -q \"diffusers>=0.14.0,<0.38.0\" \"transformers==4.53.3\" \"gradio>=4.19\" \"torch==2.8\" \"torchvision==0.23.0\" Pillow opencv-python \"git+https://github.com/huggingface/optimum-intel.git\" --extra-index-url https://download.pytorch.org/whl/cpu"
    ]
   },
   {

--- a/notebooks/stable-diffusion-v3/stable-diffusion-v3.ipynb
+++ b/notebooks/stable-diffusion-v3/stable-diffusion-v3.ipynb
@@ -64,7 +64,7 @@
     "import platform\n",
     "\n",
     "%pip uninstall -q -y optimum optimum-intel optimum-onnx\n",
-    "%pip install -q \"gradio>=4.19,<6\" \"diffusers>=0.30.0\" \"torch==2.8\"  \"transformers[sentencepiece]==4.53.3\" \"nncf>=2.12.0\" \"datasets>=2.14.6,<4.0.0\" \"opencv-python\" \"pillow\" \"peft>=0.15.0\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
+    "%pip install -q \"gradio>=4.19,<6\" \"diffusers>=0.30.0,<0.38.0\" \"torch==2.8\"  \"transformers[sentencepiece]==4.53.3\" \"nncf>=2.12.0\" \"datasets>=2.14.6,<4.0.0\" \"opencv-python\" \"pillow\" \"peft>=0.15.0\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install -q \"git+https://github.com/huggingface/optimum-intel.git\" --extra-index-url https://download.pytorch.org/whl/cpu\n",
     "%pip install -qU --pre \"openvino>=2025.4.0\" \"openvino-tokenizers>=2025.4\" \"openvino-genai>=2025.4\" --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly\n",
     "\n",


### PR DESCRIPTION
Ticket: 186131
Adds an upper bound for diffusers in notebooks that use optimum-cli together with older pinned transformers versions. It prevents recent diffusers releases from pulling in imports that are incompatible with the current notebook dependencies.