### PR TITLE
[sam3] Fix BFloat16 dtype mismatch on CPU inference

### DIFF
--- a/notebooks/sam3/sam3-segmentation.ipynb
+++ b/notebooks/sam3/sam3-segmentation.ipynb
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "1a53a882",
    "metadata": {},
    "outputs": [
@@ -224,6 +224,16 @@
     "    ],\n",
     ")\n",
     "\n",
+    "# addmm_act in perflib/fused.py unconditionally casts tensors to bfloat16\n",
+    "# and calls torch.ops.aten._addmm_activation (CUDA-only fused kernel).\n",
+    "# Replace with standard PyTorch ops for CPU inference.\n",
+    "_patch_file(\n",
+    "    sam3_pkg / \"model\" / \"vitdet.py\",\n",
+    "    [\n",
+    "        (\"x = addmm_act(type(self.act), self.fc1, x)\", \"x = self.act(self.fc1(x))\"),\n",
+    "    ],\n",
+    ")\n",
+    "\n",
     "print(\"CPU patches applied.\")\n",
     "\n",
     "# ---------------------------------------------------------------------------\n",
@@ -321,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "dc647e67",
    "metadata": {},
    "outputs": [
@@ -350,6 +360,7 @@
     "    enable_inst_interactivity=True,\n",
     "    compile=False,\n",
     ")\n",
+    "model.float()  # SAM3 checkpoint stores BFloat16 weights; cast to Float32 for CPU inference\n",
     "print(f\"Model loaded on CPU with {sum(p.numel() for p in model.parameters()) / 1e6:.1f}M parameters\")"
    ]
   },


### PR DESCRIPTION
ticket: 183955
- addmm_act() in perflib/fused.py unconditionally casts tensors to bfloat16 and uses CUDA-only _addmm_activation kernel. Patched vitdet.py to use standard self.act(self.fc1(x)) instead.
- SAM3 checkpoint stores weights in bfloat16. Added model.float() to cast to float32 for CPU inference.