### PR TITLE
Fix `stable-diffusion-v3` notebook crash on GPU in CI

### DIFF
--- a/notebooks/stable-diffusion-v3/stable-diffusion-v3.ipynb
+++ b/notebooks/stable-diffusion-v3/stable-diffusion-v3.ipynb
@@ -214,12 +214,50 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
+   "id": "8f168e7b-4352-4e1c-90f0-d6f6d9919215",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ea/work/py311/lib/python3.11/site-packages/openvino/runtime/__init__.py:10: DeprecationWarning: The `openvino.runtime` module is deprecated and will be removed in the 2026.0 release. Please replace `openvino.runtime` with `openvino`.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2477aae277844583a53a0aa9fe55dd5f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Dropdown(description='Device:', index=1, options=('CPU', 'AUTO'), value='AUTO')"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from notebook_utils import device_widget\n",
+    "\n",
+    "device = device_widget()\n",
+    "\n",
+    "device"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "id": "cda9aa51",
    "metadata": {
     "test_replace": {
      "64": "-1",
-     "model_id = model_selector.value": "model_id = \"katuni4ka/tiny-random-stable-diffusion-3\""
+     "model_id = model_selector.value": "model_id = \"katuni4ka/tiny-random-stable-diffusion-3\"\nto_compress.value = not device.value.startswith(\"GPU\")"
     }
    },
    "outputs": [
@@ -282,44 +320,6 @@
    "source": [
     "## Run OpenVINO model\n",
     "[back to top ⬆️](#Table-of-contents:)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "8f168e7b-4352-4e1c-90f0-d6f6d9919215",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ea/work/py311/lib/python3.11/site-packages/openvino/runtime/__init__.py:10: DeprecationWarning: The `openvino.runtime` module is deprecated and will be removed in the 2026.0 release. Please replace `openvino.runtime` with `openvino`.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2477aae277844583a53a0aa9fe55dd5f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Dropdown(description='Device:', index=1, options=('CPU', 'AUTO'), value='AUTO')"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from notebook_utils import device_widget\n",
-    "\n",
-    "device = device_widget()\n",
-    "\n",
-    "device"
    ]
   },
   {


### PR DESCRIPTION
## Summary
The `stable-diffusion-v3` notebook crashes in Windows GPU CI during the first generate() call, killing the Jupyter kernel. Root cause is a GPU-plugin oneDNN INT4 MatMul primitive-descriptor failure hit by the tiny random model that CI substitutes for the real model. This PR disables INT4 weight compression on GPU only, in CI only.

##  Symptom
On the nightly notebooks-tests-windows GPU job (Intel Arc B390), cell executing `ov_pipe.generate(...)`:
```
  Unhandled exception caught in c10/util/AbortHandler.h
  nbclient.exceptions.DeadKernelError: Kernel died
```
With the progress callback temporarily removed for diagnosis, the real, previously-masked error surfaced:
```
  RuntimeError: Exception from src\inference\src\cpp\infer_request.cpp:224:
  could not create a primitive descriptor for the matmul primitive.
```
##  Root cause
`ONEDNN_VERBOSE=all` on the GPU run pinned it to the INT4-weight-compressed CLIP text-encoder MatMul (src:s8 _ wei:u4 _ dst:f16, grouped scales + u8 zero-points). The fatal line is:
```
  onednn_verbose,...,create:check,matmul,bad dimension weights:1,src\common\matmul.cpp:646
```
This is triggered by the degenerate dimensions of the CI test model `katuni4ka/tiny-random-stable-diffusion-3` (CLIP `hidden_size=32`, `intermediate_size=37` - prime, which is why CI already patches int4 `group-size 64 -> -1`). It is not reproducible on real full-size SD3.5, whose CLIP dims are large and well-aligned. So this is a CI-fixture artifact, not a product defect in the notebook.

The underlying GPU-plugin limitation (hard-throw instead of graceful handling for this degenerate INT4 MatMul) is being handed to GPU plugin engineering separately; this PR unblocks CI without waiting on that fix.
##   Change
Two edits to `notebooks/stable-diffusion-v3/stable-diffusion-v3.ipynb`:
  1. Move the device-selection cell above the model-conversion cell (pure reorder; both cells keep pristine source). Needed so device.value is available when conversion decides the weight format.
  2. Add a CI-only, device-gated compression override via existing cell `test_replace` metadata:
  ```
  to_compress.value = not device.value.startswith("GPU")
  ```
##  Ticket
CVS-169391