### PR TITLE
[NPU] Kokoro notebook: update OpenVINO version required for current flow

### DIFF
--- a/notebooks/kokoro/kokoro.ipynb
+++ b/notebooks/kokoro/kokoro.ipynb
@@ -12,7 +12,7 @@
         "\n",
         "<div class=\"alert alert-block alert-info\"><b>Python support:</b> Inference with the preconverted model supports Python 3.10 and newer, including Python 3.13. Local export uses the <code>kokoro</code> and <code>misaki</code> Python packages and therefore requires Python &lt; 3.13.</div>\n",
         "\n",
-        "<div class=\"alert alert-block alert-warning\"><b>NPU support:</b> Kokoro requires OpenVINO 2026.3 or later and a compatible NPU driver. See the <a href=\"https://docs.openvino.ai/2026/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.html\">NPU device guide</a>.</div>\n",
+        "<div class=\"alert alert-block alert-warning\"><b>NPU support:</b> Kokoro requires OpenVINO 2026.4 (nightly) or later and a compatible NPU driver. See the <a href=\"https://docs.openvino.ai/2026/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.html\">NPU device guide</a>.</div>\n",
         "\n",
         "#### Table of contents:\n",
         "\n",


### PR DESCRIPTION
Current flow of Kokoro notebook (recently changed to optimum export) requires changes of OpenVINO (NPUW) which are only included in OV2026.4 release.

Tested: notebook doesn't work with OV 2026.3.0, 2026.3.1 with NPU device selected, both for pre-converted and runtime-converted models