### PR TITLE
docs: fix broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,8 @@ To do this, there are a few requirements that all notebooks need to pass.
    - Add a `README.md` to the notebook subdirectory. Add a screenshot that gives an indication of what
      the notebook does if applicable.
    - Avoid adding any other files to the notebook's subdirectory. Instead, rely on models and data samples available online and fetch them within the notebook. Please refer to the [Notebook utils](#notebook-utils) section.
-3. In case you want to utilize one of the Open Model Zoo models, refer to the [Model Tools](https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/model-tools)
-   notebook.
+3. In case you want to utilize one of the Open Model Zoo models, refer to the [Model Tools](https://github.com/openvinotoolkit/open_model_zoo/tree/master/tools/model_tools)
+   documentation.
 4. The notebooks should provide an easy way to clean up the downloaded data, for example with a
    commented-out cell at the end of the notebook.
 
@@ -334,7 +334,7 @@ standard `diff` tool for `git`, with much more useful output than the regular `g
 
 #### JupyterLab Code Formatter
 
-[JupyterLab Code Formatter](https://ryantam626.github.io/jupyterlab_code_formatter/index.html) adds a
+[JupyterLab Code Formatter](https://jupyterlab-code-formatter.readthedocs.io/) adds a
 button to Jupyter Lab to automatically format the code in notebooks with `black` and `isort`. Please
 use either this extension or a different way to automatically format your notebook.
 


### PR DESCRIPTION
## Description

Fixes two broken links in `CONTRIBUTING.md`.

**1. JupyterLab Code Formatter (line 337)**

The `ryantam626.github.io/jupyterlab_code_formatter` GitHub Pages site is no longer served — it returns 404 with `Site not found · GitHub Pages`. The project's Read the Docs site is live, so this points back to `https://jupyterlab-code-formatter.readthedocs.io/`.

Slightly amusing history: #919 originally moved this link *from* Read the Docs *to* the GitHub Pages site back in 2023. That site has since gone away and Read the Docs is the one still up, so this moves it back.

**2. Model Tools (line 99)**

`notebooks/model-tools` no longer exists in this repository (the URL 404s, and `git ls-tree -r HEAD` finds no `model-tools` path), so the guidance for using Open Model Zoo models points at nothing.

Rather than dropping the item, this repoints it to Open Model Zoo's own Model Tools directory — `open_model_zoo/tools/model_tools`, titled "Model Downloader and other automation tools" — which is what the removed notebook demonstrated. Since it is a tools directory rather than a notebook, the trailing word was changed from `notebook.` to `documentation.` to match. `README.md:208` already links to Open Model Zoo for a similar purpose.

If you would rather delete the item entirely, I'm happy to change it.

## How I checked

Extracted every http(s) URL from the repository's Markdown files and resolved each one with `curl -L`, keeping only genuine 404s — redirects that still resolve were left untouched. Both replacement targets return 200. Documentation-only change; no notebooks or code touched.

_Disclosure: prepared with AI assistance; both links were verified manually._
