### PR TITLE
[notebooks] Fix OmniVoice audio encoder conversion broken by transformers 5.17

### DIFF
--- a/notebooks/omnivoice/omnivoice.ipynb
+++ b/notebooks/omnivoice/omnivoice.ipynb
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "295844db",
    "metadata": {},
    "outputs": [],
@@ -96,7 +96,7 @@
     "    \"https://download.pytorch.org/whl/cpu\",\n",
     "    \"torch>=2.4\",\n",
     "    \"torchaudio>=2.4\",\n",
-    "    \"transformers>=5.17\",\n",
+    "    \"transformers>=5.3\",\n",
     "    \"openvino>=2026.1\",\n",
     "    \"openvino-genai>=2026.1\",\n",
     "    \"nncf\",\n",

--- a/notebooks/omnivoice/omnivoice.ipynb
+++ b/notebooks/omnivoice/omnivoice.ipynb
@@ -96,7 +96,7 @@
     "    \"https://download.pytorch.org/whl/cpu\",\n",
     "    \"torch>=2.4\",\n",
     "    \"torchaudio>=2.4\",\n",
-    "    \"transformers>=5.3\",\n",
+    "    \"transformers>=5.17\",\n",
     "    \"openvino>=2026.1\",\n",
     "    \"openvino-genai>=2026.1\",\n",
     "    \"nncf\",\n",

--- a/notebooks/omnivoice/omnivoice.ipynb
+++ b/notebooks/omnivoice/omnivoice.ipynb
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "295844db",
    "metadata": {},
    "outputs": [],
@@ -96,7 +96,7 @@
     "    \"https://download.pytorch.org/whl/cpu\",\n",
     "    \"torch>=2.4\",\n",
     "    \"torchaudio>=2.4\",\n",
-    "    \"transformers>=5.3\",\n",
+    "    \"transformers>=5.17\",\n",
     "    \"openvino>=2026.1\",\n",
     "    \"openvino-genai>=2026.1\",\n",
     "    \"nncf\",\n",

--- a/notebooks/omnivoice/omnivoice_helper.py
+++ b/notebooks/omnivoice/omnivoice_helper.py
@@ -284,7 +284,7 @@ def _convert_audio_tokenizer(
             for layer in self_.layers:
                 if output_hidden_states:
                     all_hidden = all_hidden + (hidden_states,)
-                # transformers>=5 HubertEncoderLayer returns a bare tensor, not a tuple
+                # transformers>=5.17 HubertEncoderLayer returns a bare tensor, not a tuple
                 hidden_states = layer(hidden_states, attention_mask=None)
             if output_hidden_states:
                 all_hidden = all_hidden + (hidden_states,)

--- a/notebooks/omnivoice/omnivoice_helper.py
+++ b/notebooks/omnivoice/omnivoice_helper.py
@@ -284,7 +284,8 @@ def _convert_audio_tokenizer(
             for layer in self_.layers:
                 if output_hidden_states:
                     all_hidden = all_hidden + (hidden_states,)
-                hidden_states = layer(hidden_states, attention_mask=None)[0]
+                # transformers>=5 HubertEncoderLayer returns a bare tensor, not a tuple
+                hidden_states = layer(hidden_states, attention_mask=None)
             if output_hidden_states:
                 all_hidden = all_hidden + (hidden_states,)
             return BaseModelOutput(


### PR DESCRIPTION
## Description

Fixes the `RuntimeError: Couldn't get TorchScript module by tracing` (caused by
`IndexError: Dimension out of range`) when converting the OmniVoice HiggsAudio
encoder to OpenVINO IR. The regression surfaced with the release of
`transformers==5.17`.

The patched HuBERT encoder forward in `omnivoice_helper.py` indexed the encoder
layer output with `[0]`, assuming a tuple return. As of `transformers` 5.17,
`HubertEncoderLayer.forward` returns a bare tensor, so `[0]` stripped the batch
dimension (`[1, seq, hidden]` → `[seq, hidden]`). The next layer's attention
then built a 3D tensor and failed at `key.transpose(2, 3)` during tracing.

## Fix

Removed the `[0]` so `hidden_states` keeps its full `[batch, seq, hidden]` shape.

## Ticket

194448